### PR TITLE
feat : 로그인 기능 구현

### DIFF
--- a/src/main/java/com/zerobase/hoops/config/SwaggerConfig.java
+++ b/src/main/java/com/zerobase/hoops/config/SwaggerConfig.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Configuration;
     ),
     tags = {
         @Tag(name = "1. USER", description = "회원 기능"),
+        @Tag(name = "2. AUTH", description = "인증/인가 기능")
     }
 )
 @Configuration

--- a/src/main/java/com/zerobase/hoops/config/WebSecurityConfig.java
+++ b/src/main/java/com/zerobase/hoops/config/WebSecurityConfig.java
@@ -47,6 +47,7 @@ public class WebSecurityConfig {
         .authorizeHttpRequests(request -> request
             .requestMatchers("/", "/api/user/**",
                 "/swagger-ui/**", "/v3/api-docs/**",
+                "/api/auth/login",
                 //로그인 개발되면 해당 부분 삭제
                 "/report/user",
                 //--------------------

--- a/src/main/java/com/zerobase/hoops/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/hoops/exception/ErrorCode.java
@@ -17,9 +17,10 @@ public enum ErrorCode {
   INVALID_NUMBER(HttpStatus.FORBIDDEN.value(), "유효하지 않은 인증번호입니다."),
   USER_NOT_CONFIRM(HttpStatus.BAD_REQUEST.value(), "인증되지 않은 회원입니다."),
 
-  NOT_FOUND_TOKEN(HttpStatus.BAD_REQUEST.value(), "Headers에 토큰 형식의 값 찾을 수 없습니다."),
+  NOT_FOUND_TOKEN(HttpStatus.BAD_REQUEST.value(), "토큰 형식의 값을 찾을 수 없습니다."),
   INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 토큰입니다."),
   EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "기간이 만료된 토큰입니다."),
+  NOT_MATCHED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "토큰 정보가 일치하지 않습니다."),
   UNSUPPORTED_TOKEN(HttpStatus.BAD_REQUEST.value(), "지원하지 않는 토큰입니다."),
 
   DUPLICATED_ID(HttpStatus.CONFLICT.value(), "이미 사용 중인 아이디입니다."),

--- a/src/main/java/com/zerobase/hoops/reports/dto/ReportDto.java
+++ b/src/main/java/com/zerobase/hoops/reports/dto/ReportDto.java
@@ -3,7 +3,6 @@ package com.zerobase.hoops.reports.dto;
 import com.zerobase.hoops.entity.ReportEntity;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Data;
@@ -27,8 +26,8 @@ public class ReportDto {
 
   public ReportEntity toEntity() {
     return ReportEntity.builder()
-        .user_id(this.userEmail)
-        .reported_id(this.reportedUserEmail)
+        .userId(this.userEmail)
+        .reportedId(this.reportedUserEmail)
         .content(this.content)
         .build();
   }

--- a/src/main/java/com/zerobase/hoops/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zerobase/hoops/security/JwtAuthenticationFilter.java
@@ -1,12 +1,7 @@
 package com.zerobase.hoops.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.zerobase.hoops.exception.CustomException;
-import com.zerobase.hoops.exception.ErrorCode;
 import com.zerobase.hoops.users.service.UserService;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -16,8 +11,6 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -37,23 +30,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   private final ObjectMapper objectMapper;
   private final UserService userService;
 
-  private String resolveTokenFromRequest(HttpServletRequest request) {
-    String token = request.getHeader(TOKEN_HEADER);
-
-    if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
-      return token.substring(TOKEN_PREFIX.length());
-    }
-    return null;
-  }
-
   @Override
   protected void doFilterInternal(
       HttpServletRequest request,
       HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
-    String token = this.resolveTokenFromRequest(request);
 
-    if (token != null && this.tokenProvider.isLogOut(token)) {
+    String accessToken = resolveTokenFromRequest(request);
+
+    if (StringUtils.hasText(accessToken) && tokenProvider.isLogOut(accessToken)) {
       response.setStatus(HttpStatus.UNAUTHORIZED.value());
       response.setContentType("application/json");
       String errorMessage = objectMapper.writeValueAsString(
@@ -62,24 +47,28 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       response.getWriter().write(errorMessage);
     }
 
-    if (StringUtils.hasText(token)
-        && this.tokenProvider.validateToken(token)) {
-      Authentication auth =
-          this.tokenProvider.getAuthentication(token);
+    if (StringUtils.hasText(accessToken) &&
+        tokenProvider.validateToken(accessToken)) {
+      Authentication auth = tokenProvider.getAuthentication(accessToken);
 
       SecurityContextHolder.getContext().setAuthentication(auth);
 
       // (블랙리스트 체크)
-      userService.checkBlackList(this.tokenProvider.getUsername(token));
+      userService.checkBlackList(tokenProvider.getUsername(accessToken));
 
-      log.info(String.format(
-          "[%s] -> %s",
-          this.tokenProvider.getUsername(token),
-          request.getRequestURI()));
+      log.info(String.format("[%s] -> %s",
+          tokenProvider.getUsername(accessToken), request.getRequestURI()));
     }
-//    // 블랙리스트 검사
-//    this.userService.checkBlackList(
-//        jwtTokenExtract.currentUser().getEmail());
+
     filterChain.doFilter(request, response);
+  }
+
+  private String resolveTokenFromRequest(HttpServletRequest request) {
+    String token = request.getHeader(TOKEN_HEADER);
+
+    if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
+      return token.substring(TOKEN_PREFIX.length());
+    }
+    return null;
   }
 }

--- a/src/main/java/com/zerobase/hoops/security/TokenProvider.java
+++ b/src/main/java/com/zerobase/hoops/security/TokenProvider.java
@@ -1,22 +1,24 @@
 package com.zerobase.hoops.security;
 
+import com.zerobase.hoops.users.repository.AuthRepository;
 import com.zerobase.hoops.users.service.UserService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import java.util.Collection;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.time.Duration;
 import java.util.Date;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -26,9 +28,11 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class TokenProvider {
 
-  private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60;
+  private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000L * 60;
   private static final long BLACK_TOKEN_EXPIRE_TIME = 1000 * 60 * 2;
+  private final static Long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60;
   private final UserService userService;
+  private final AuthRepository authRepository;
 
   @Getter
   private final Set<String> logOut =
@@ -37,25 +41,54 @@ public class TokenProvider {
   @Value("${spring.jwt.secret}")
   private String secretKey;
 
-  public String generateToken(String email) {
+  /**
+   * AccessToken 생성
+   */
+  public String createAccessToken(String id, String email, List<String> role) {
+    return generateToken(id, email, role, ACCESS_TOKEN_EXPIRE_TIME);
+  }
+
+  /**
+   * RefreshToken 생성
+   */
+  public String createRefreshToken(String id, String email, List<String> role) {
+
+    String refreshToken =
+        generateToken(id, email, role, REFRESH_TOKEN_EXPIRE_TIME);
+
+    authRepository.saveRefreshToken(
+        id, refreshToken, Duration.ofMillis(REFRESH_TOKEN_EXPIRE_TIME));
+    return refreshToken;
+  }
+
+  public String generateToken(String id, String email, List<String> roles, Long expireTime) {
 
     Claims claims = Jwts.claims().setSubject(email);
+    claims.put("id", id);
+    claims.put("roles", roles);
 
     var now = new Date();
-    var expireDate = new Date(now.getTime() + TOKEN_EXPIRE_TIME);
+    var expireDate = new Date(now.getTime() + expireTime);
 
     return Jwts.builder()
         .setClaims(claims)
         .setIssuedAt(now)
         .setExpiration(expireDate)
-        .signWith(SignatureAlgorithm.HS512, this.secretKey)
+        .signWith(getSigningKey(secretKey.getBytes(StandardCharsets.UTF_8)))
         .compact();
+  }
+
+  public static Key getSigningKey(byte[] secretKey) {
+    return Keys.hmacShaKeyFor(secretKey);
   }
 
   public Claims parseClaims(String token) {
     try {
-      return Jwts.parser().setSigningKey(this.secretKey)
-          .parseClaimsJws(token).getBody();
+      return Jwts.parserBuilder()
+          .setSigningKey(getSigningKey(secretKey.getBytes(StandardCharsets.UTF_8)))
+          .build()
+          .parseClaimsJws(token)
+          .getBody();
     } catch (ExpiredJwtException e) {
       return e.getClaims();
     }

--- a/src/main/java/com/zerobase/hoops/security/TokenProvider.java
+++ b/src/main/java/com/zerobase/hoops/security/TokenProvider.java
@@ -29,8 +29,8 @@ import org.springframework.util.StringUtils;
 public class TokenProvider {
 
   private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000L * 60;
-  private static final long BLACK_TOKEN_EXPIRE_TIME = 1000 * 60 * 2;
-  private final static Long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60;
+  private static final long BLACK_TOKEN_EXPIRE_TIME = 1000L * 60 * 2;
+  private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60;
   private final UserService userService;
   private final AuthRepository authRepository;
 

--- a/src/main/java/com/zerobase/hoops/users/controller/AuthController.java
+++ b/src/main/java/com/zerobase/hoops/users/controller/AuthController.java
@@ -1,0 +1,47 @@
+package com.zerobase.hoops.users.controller;
+
+import com.zerobase.hoops.users.dto.LogInDto;
+import com.zerobase.hoops.users.dto.TokenDto;
+import com.zerobase.hoops.users.dto.UserDto;
+import com.zerobase.hoops.users.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@Tag(name = "2. AUTH")
+public class AuthController {
+
+  private final AuthService authService;
+
+  /**
+   * 로그인
+   */
+  @Operation(summary = "로그인")
+  @PostMapping("/login")
+  public ResponseEntity<?> logIn(
+      @RequestBody @Validated LogInDto.Request request
+  ) {
+    UserDto userDto = authService.logInUser(request);
+
+    TokenDto tokenDto = authService.getToken(userDto);
+
+    HttpHeaders responseHeaders = new HttpHeaders();
+    responseHeaders.set("Authorization", tokenDto.getAccessToken());
+
+    return ResponseEntity.ok()
+        .headers(responseHeaders)
+        .body(LogInDto.Response.fromDto(userDto, tokenDto.getRefreshToken()));
+  }
+}

--- a/src/main/java/com/zerobase/hoops/users/controller/UserController.java
+++ b/src/main/java/com/zerobase/hoops/users/controller/UserController.java
@@ -1,12 +1,10 @@
 package com.zerobase.hoops.users.controller;
 
-import com.zerobase.hoops.security.TokenProvider;
 import com.zerobase.hoops.users.dto.SignUpDto;
 import com.zerobase.hoops.users.dto.UserDto;
 import com.zerobase.hoops.users.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -26,8 +24,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
   private final UserService userService;
-
-  private final TokenProvider tokenProvider;
 
   /**
    * 회원 가입
@@ -96,14 +92,4 @@ public class UserController {
 
     return ResponseEntity.status(HttpStatus.FOUND).location(loginPage).build();
   }
-
-  /**
-   * 로그인 테스트용
-   */
-  @GetMapping("/testLogin")
-  public ResponseEntity<?> testLogin(@RequestParam(name = "email") String email) {
-    var token = this.tokenProvider.generateToken(email);
-    return ResponseEntity.ok(token);
-  }
-
 }

--- a/src/main/java/com/zerobase/hoops/users/dto/LogInDto.java
+++ b/src/main/java/com/zerobase/hoops/users/dto/LogInDto.java
@@ -1,0 +1,68 @@
+package com.zerobase.hoops.users.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class LogInDto {
+
+  @Getter
+  @Setter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder
+  public static class Request {
+
+    @NotBlank(message = "아이디를 입력하세요.")
+    private String id;
+
+    @NotBlank(message = "비밀번호를 입력하세요.")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[~!@#$%^&*()])"
+        + "[a-zA-Z0-9~!@#$%^&*()]{8,13}$")
+    private String password;
+  }
+
+  @Getter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder
+  public static class Response {
+
+    private Long userId;
+    private String id;
+    private String email;
+    private String name;
+    private LocalDate birthday;
+    private String gender;
+    private String nickName;
+    private LocalDateTime crateDate;
+    private String playStyle;
+    private String ability;
+    private List<String> roles;
+    private String refreshToken;
+
+    public static Response fromDto(UserDto userDto, String refreshToken) {
+      return Response.builder()
+          .userId(userDto.getUserId())
+          .id(userDto.getId())
+          .email(userDto.getEmail())
+          .name(userDto.getName())
+          .birthday(userDto.getBirthday())
+          .gender(userDto.getGender())
+          .nickName(userDto.getNickName())
+          .crateDate(userDto.getCreateDate())
+          .playStyle(userDto.getPlayStyle())
+          .ability(userDto.getAbility())
+          .roles(userDto.getRoles())
+          .refreshToken(refreshToken)
+          .build();
+    }
+  }
+}

--- a/src/main/java/com/zerobase/hoops/users/dto/SignUpDto.java
+++ b/src/main/java/com/zerobase/hoops/users/dto/SignUpDto.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Pattern;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -74,7 +75,7 @@ public class SignUpDto {
           .nickName(request.getNickName())
           .playStyle(PlayStyleType.valueOf(request.getPlayStyle()))
           .ability(AbilityType.valueOf(request.getAbility()))
-          .roles(List.of("ROLE_USER"))
+          .roles(new ArrayList<>(List.of("ROLE_USER")))
           .build();
     }
   }

--- a/src/main/java/com/zerobase/hoops/users/dto/TokenDto.java
+++ b/src/main/java/com/zerobase/hoops/users/dto/TokenDto.java
@@ -1,0 +1,17 @@
+package com.zerobase.hoops.users.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TokenDto {
+
+  private String id;
+  private String accessToken;
+  private String refreshToken;
+}

--- a/src/main/java/com/zerobase/hoops/users/repository/AuthRepository.java
+++ b/src/main/java/com/zerobase/hoops/users/repository/AuthRepository.java
@@ -1,0 +1,19 @@
+package com.zerobase.hoops.users.repository;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AuthRepository {
+
+  private final StringRedisTemplate redisTemplate;
+
+  public void saveRefreshToken(
+      String id, String refreshToken, Duration duration
+  ) {
+    redisTemplate.opsForValue().set(id, refreshToken, duration);
+  }
+}

--- a/src/main/java/com/zerobase/hoops/users/repository/UserRepository.java
+++ b/src/main/java/com/zerobase/hoops/users/repository/UserRepository.java
@@ -18,4 +18,6 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
   Optional<UserEntity> findByEmail(String email);
 
+  Optional<UserEntity> findByIdAndDeleteDateTimeNull(String id);
+
 }

--- a/src/main/java/com/zerobase/hoops/users/service/AuthService.java
+++ b/src/main/java/com/zerobase/hoops/users/service/AuthService.java
@@ -29,7 +29,8 @@ public class AuthService {
 
   public UserDto logInUser(LogInDto.Request request) {
 
-    UserEntity user = userRepository.findById(request.getId())
+    UserEntity user =
+        userRepository.findByIdAndDeleteDateTimeNull(request.getId())
         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
     String password = request.getPassword();

--- a/src/main/java/com/zerobase/hoops/users/service/AuthService.java
+++ b/src/main/java/com/zerobase/hoops/users/service/AuthService.java
@@ -1,0 +1,59 @@
+package com.zerobase.hoops.users.service;
+
+import com.zerobase.hoops.entity.UserEntity;
+import com.zerobase.hoops.exception.CustomException;
+import com.zerobase.hoops.exception.ErrorCode;
+import com.zerobase.hoops.security.TokenProvider;
+import com.zerobase.hoops.users.dto.LogInDto;
+import com.zerobase.hoops.users.dto.TokenDto;
+import com.zerobase.hoops.users.dto.UserDto;
+import com.zerobase.hoops.users.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class AuthService {
+
+  private final UserRepository userRepository;
+
+  private final TokenProvider tokenProvider;
+
+  private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+  public UserDto logInUser(LogInDto.Request request) {
+
+    UserEntity user = userRepository.findById(request.getId())
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+    String password = request.getPassword();
+    String encodedPassword = user.getPassword();
+    boolean isMatched = passwordEncoder.matches(password, encodedPassword);
+    if (!isMatched) {
+      throw new CustomException(ErrorCode.NOT_MATCHED_PASSWORD);
+    }
+
+    if (!user.isEmailAuth()) {
+      throw new CustomException(ErrorCode.USER_NOT_CONFIRM);
+    }
+
+    return UserDto.fromEntity(user);
+  }
+
+  public TokenDto getToken(UserDto userDto) {
+    String accessToken =
+        tokenProvider.createAccessToken(userDto.getId(),
+            userDto.getEmail(), userDto.getRoles());
+    String refreshToken =
+        tokenProvider.createRefreshToken(userDto.getId(),
+            userDto.getEmail(), userDto.getRoles());
+
+    return new TokenDto(userDto.getId(), accessToken, refreshToken);
+  }
+}

--- a/src/main/java/com/zerobase/hoops/users/service/UserService.java
+++ b/src/main/java/com/zerobase/hoops/users/service/UserService.java
@@ -77,21 +77,15 @@ public class UserService implements UserDetailsService {
           userRepository.save(Request.toEntity(request));
 
       return UserDto.fromEntity(signUpUser);
-    } catch (CustomException e) {
-      throw new CustomException(e.getErrorCode(), e.getErrorMessage());
     } catch (NoSuchAlgorithmException e) {
       throw new RuntimeException(e);
     }
   }
 
   public boolean idCheck(String id) {
-    try {
-      boolean isExistId = userRepository.existsById(id);
-      if (isExistId) {
-        throw new CustomException(ErrorCode.DUPLICATED_ID);
-      }
-    } catch (CustomException e) {
-      throw new CustomException(e.getErrorCode(), e.getErrorMessage());
+    boolean isExistId = userRepository.existsById(id);
+    if (isExistId) {
+      throw new CustomException(ErrorCode.DUPLICATED_ID);
     }
 
     return true;
@@ -145,10 +139,9 @@ public class UserService implements UserDetailsService {
       throw new CustomException(ErrorCode.WRONG_EMAIL);
     }
 
-    return (validatedEmail && emailRepository
-        .getCertificationNumber(email)
-        .equals(certificationNumber)
-    );
+    return emailRepository
+            .getCertificationNumber(email)
+            .equals(certificationNumber);
   }
 
   @Override

--- a/src/test/java/com/zerobase/hoops/reports/service/ReportServiceTest.java
+++ b/src/test/java/com/zerobase/hoops/reports/service/ReportServiceTest.java
@@ -104,9 +104,9 @@ class ReportServiceTest {
     ReportEntity savedReportEntity = reportEntityCaptor.getValue();
     assertThat(savedReportEntity.getContent()).isEqualTo(
         reportDto.getContent());
-    assertThat(savedReportEntity.getUser_id()).isEqualTo(
+    assertThat(savedReportEntity.getUserId()).isEqualTo(
         userEntity.getEmail());
-    assertThat(savedReportEntity.getReported_id()).isEqualTo(
+    assertThat(savedReportEntity.getReportedId()).isEqualTo(
         reportedUserEntity.getEmail());
   }
 

--- a/src/test/java/com/zerobase/hoops/users/service/AuthServiceTest.java
+++ b/src/test/java/com/zerobase/hoops/users/service/AuthServiceTest.java
@@ -1,0 +1,159 @@
+package com.zerobase.hoops.users.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.zerobase.hoops.entity.UserEntity;
+import com.zerobase.hoops.exception.CustomException;
+import com.zerobase.hoops.exception.ErrorCode;
+import com.zerobase.hoops.users.dto.LogInDto;
+import com.zerobase.hoops.users.dto.SignUpDto;
+import com.zerobase.hoops.users.dto.UserDto;
+import com.zerobase.hoops.users.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class AuthServiceTest {
+
+  @Autowired
+  AuthService authService;
+
+  @Autowired
+  UserService userService;
+
+  @Autowired
+  UserRepository userRepository;
+
+  @BeforeEach
+  void insertTestUser() {
+    userService.signUpUser(SignUpDto.Request.builder()
+        .id("basketman")
+        .password("Abcdefg123$%")
+        .passwordCheck("Abcdefg123$%")
+        .email("testMail@hoops.com")
+        .name("농구공")
+        .birthday(LocalDate.parse("18900101", DateTimeFormatter.ofPattern(
+            "yyyyMMdd")))
+        .gender("MALE")
+        .nickName("농구짱")
+        .playStyle("AGGRESSIVE")
+        .ability("PASS")
+        .build());
+
+    userService.signUpUser(SignUpDto.Request.builder()
+        .id("testUser")
+        .password("Abcdefg123$%")
+        .passwordCheck("Abcdefg123$%")
+        .email("test@hoops.com")
+        .name("테스트")
+        .birthday(LocalDate.parse("19900101", DateTimeFormatter.ofPattern(
+            "yyyyMMdd")))
+        .gender("MALE")
+        .nickName("별명")
+        .playStyle("BALANCE")
+        .ability("SHOOT")
+        .build());
+
+    UserEntity user = userRepository.findById("testUser")
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    user.confirm();
+    userRepository.save(user);
+    System.out.println("인증 결과 : " + user.isEmailAuth());
+  }
+
+  @Test
+  @DisplayName("LogIn_User_Success")
+  void logInUserTestSuccess() {
+    PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+    // given
+    LogInDto.Request request = LogInDto.Request.builder()
+        .id("testUser")
+        .password("Abcdefg123$%")
+        .build();
+
+    // when
+    UserDto user = authService.logInUser(request);
+
+    // then
+    assertEquals(user.getUserId(), 12);
+    assertEquals(user.getId(), "testUser");
+    assertTrue(passwordEncoder.matches(
+        "Abcdefg123$%", user.getPassword())
+    );
+    assertEquals(user.getEmail(), "test@hoops.com");
+    assertEquals(user.getName(), "테스트");
+    assertEquals(user.getBirthday(), LocalDate
+        .parse("19900101", DateTimeFormatter.ofPattern("yyyyMMdd")));
+    assertEquals(user.getGender(), "MALE");
+    assertEquals(user.getNickName(), "별명");
+    assertEquals(user.getPlayStyle(), "BALANCE");
+    assertEquals(user.getAbility(), "SHOOT");
+    for (int i = 0; i < user.getRoles().size(); i++) {
+      assertEquals(user.getRoles().get(i), "ROLE_USER");
+    }
+  }
+
+  @Test
+  @DisplayName("LogIn_User_Fail_User_Not_Found")
+  void logInUserFailTest_UserNotFound() {
+    // given
+    LogInDto.Request request = LogInDto.Request.builder()
+        .id("nouser")
+        .password("Abcdefg123$%")
+        .build();
+
+    // when
+    Throwable exception = assertThrows(CustomException.class, () ->
+        authService.logInUser(request));
+
+    // then
+    assertThrows(CustomException.class, () -> authService.logInUser(request));
+    assertEquals("아이디가 존재하지 않습니다.", exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("LogIn_User_Fail_Not_Matched_Password")
+  void logInUserFailTest_NotMatchedPassword() {
+    // given
+    LogInDto.Request request = LogInDto.Request.builder()
+        .id("testUser")
+        .password("Abcdefg123$")
+        .build();
+
+    // when
+    Throwable exception = assertThrows(CustomException.class, () ->
+        authService.logInUser(request));
+
+    // then
+    assertThrows(CustomException.class, () -> authService.logInUser(request));
+    assertEquals("비밀번호가 일치하지 않습니다.", exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("LogIn_User_Fail_Not_Confirmed_Auth")
+  void logInUserFailTest_NotConfirmedAuth() {
+    // given
+    LogInDto.Request request = LogInDto.Request.builder()
+        .id("basketman")
+        .password("Abcdefg123$%")
+        .build();
+
+    // when
+    Throwable exception = assertThrows(CustomException.class, () ->
+        authService.logInUser(request));
+
+    // then
+    assertThrows(CustomException.class, () -> authService.logInUser(request));
+    assertEquals("인증되지 않은 회원입니다.", exception.getMessage());
+  }
+
+}


### PR DESCRIPTION
 - 로그인 성공 시 access token, refresh token 발급

### 변경사항
**AS-IS**
 - 회원 가입

**TO-BE**
 - 로그인 기능
	 - id, password 유효성 검증
	 - API 요청 시 입력한 password 와 DB에 저장된 encoded password 비교 : BCryptPasswordEncoder.matches()
	 - 회원 가입 시 진행하는 메일 인증 여부 검증
	 - 로그인 검증 완료 후 access token, refresh token 생성

### 테스트
- [x] 테스트 코드
- [x] API 테스트 