### PR TITLE
feat : 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/zerobase/hoops/users/controller/AuthController.java
+++ b/src/main/java/com/zerobase/hoops/users/controller/AuthController.java
@@ -1,16 +1,21 @@
 package com.zerobase.hoops.users.controller;
 
+import com.zerobase.hoops.entity.UserEntity;
 import com.zerobase.hoops.users.dto.LogInDto;
 import com.zerobase.hoops.users.dto.LogInDto.Response;
 import com.zerobase.hoops.users.dto.TokenDto;
 import com.zerobase.hoops.users.dto.UserDto;
 import com.zerobase.hoops.users.service.AuthService;
+import com.zerobase.hoops.users.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
   private final AuthService authService;
+  private final UserService userService;
 
   /**
    * 로그인
@@ -44,5 +50,39 @@ public class AuthController {
     return ResponseEntity.ok()
         .headers(responseHeaders)
         .body(LogInDto.Response.fromDto(userDto, tokenDto.getRefreshToken()));
+  }
+
+  /**
+   * refresh
+   */
+  @Operation(summary = "refresh")
+  @PostMapping("/refresh-token")
+  public ResponseEntity<?> refreshToken(
+      HttpServletRequest request,
+      @AuthenticationPrincipal UserEntity userEntity
+  ) {
+    TokenDto tokenDto = authService.refreshToken(request, userEntity);
+    UserDto userDto = userService.getUserInfo(tokenDto.getId());
+
+    HttpHeaders responseAccessToken = new HttpHeaders();
+    responseAccessToken.set("Authorization", tokenDto.getAccessToken());
+
+    return ResponseEntity.ok()
+        .headers(responseAccessToken)
+        .body(LogInDto.Response.fromDto(userDto, tokenDto.getRefreshToken()));
+  }
+
+  /**
+   * 로그아웃
+   */
+  @Operation(summary = "로그아웃")
+  @PostMapping("/logout")
+  public ResponseEntity<?> logOut(
+      HttpServletRequest request,
+      @AuthenticationPrincipal UserEntity userEntity
+  ) {
+    authService.logOutUser(request, userEntity);
+
+    return ResponseEntity.ok(HttpStatus.OK);
   }
 }

--- a/src/main/java/com/zerobase/hoops/users/controller/AuthController.java
+++ b/src/main/java/com/zerobase/hoops/users/controller/AuthController.java
@@ -57,7 +57,7 @@ public class AuthController {
    */
   @Operation(summary = "refresh")
   @PostMapping("/refresh-token")
-  public ResponseEntity<?> refreshToken(
+  public ResponseEntity<Response> refreshToken(
       HttpServletRequest request,
       @AuthenticationPrincipal UserEntity userEntity
   ) {
@@ -77,7 +77,7 @@ public class AuthController {
    */
   @Operation(summary = "로그아웃")
   @PostMapping("/logout")
-  public ResponseEntity<?> logOut(
+  public ResponseEntity<HttpStatus> logOut(
       HttpServletRequest request,
       @AuthenticationPrincipal UserEntity userEntity
   ) {

--- a/src/main/java/com/zerobase/hoops/users/controller/UserController.java
+++ b/src/main/java/com/zerobase/hoops/users/controller/UserController.java
@@ -6,9 +6,7 @@ import com.zerobase.hoops.users.dto.UserDto;
 import com.zerobase.hoops.users.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.net.URI;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -82,15 +80,13 @@ public class UserController {
    */
   @Operation(summary = "이메일 인증")
   @GetMapping("/signup/confirm")
-  public ResponseEntity<URI> confirmCertificationNumber(
+  public ResponseEntity<String> confirmCertificationNumber(
       @RequestParam(name = "id") String id,
       @RequestParam(name = "email") String email,
       @RequestParam(name = "certificationNumber") String certificationNumber
-  ) throws Exception {
+  ) {
     userService.confirmEmail(id, email, certificationNumber);
 
-    URI loginPage = new URI("/api/user/login");
-
-    return ResponseEntity.status(HttpStatus.FOUND).location(loginPage).build();
+    return ResponseEntity.ok("인증이 성공적으로 완료되었습니다.");
   }
 }

--- a/src/main/java/com/zerobase/hoops/users/repository/AuthRepository.java
+++ b/src/main/java/com/zerobase/hoops/users/repository/AuthRepository.java
@@ -16,4 +16,12 @@ public class AuthRepository {
   ) {
     redisTemplate.opsForValue().set(id, refreshToken, duration);
   }
+
+  public void findById(String id) {
+    redisTemplate.opsForValue().get(id);
+  }
+
+  public void deleteById(String id) {
+    redisTemplate.delete(id);
+  }
 }

--- a/src/main/java/com/zerobase/hoops/users/service/UserService.java
+++ b/src/main/java/com/zerobase/hoops/users/service/UserService.java
@@ -145,6 +145,12 @@ public class UserService implements UserDetailsService {
         .equals(certificationNumber);
   }
 
+  public UserDto getUserInfo(String userId) {
+    UserEntity userEntity = userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    return UserDto.fromEntity(userEntity);
+  }
+
   @Override
   public UserDetails loadUserByUsername(String email)
       throws UsernameNotFoundException {


### PR DESCRIPTION
### 변경사항
**AS-IS**
 - 이메일 인증 시 에러 코드 반환

**TO-BE**
 - 이메일 인증 시 인증 완료 문구 반환
 - 로그아웃 기능 구현
	 - accesss token, refresh token 을 header에 담아 요청
	 - 토큰 유효성 검증
	 - 검증 완료 시 refresh token 삭제, access token logout list 추가
 - 로그 아웃 요청 시 access token 이 만료되었다면 에러 코드 반환
 - refresh token 으로 access token 재발급
	 - 만료된 access token 과 refresh token 회원 정보 일치 확인
	 - 로그인 된 회원과 토큰 정보 일치 확인
	 - redis에 저장된 refresh token 이 있다면 access token 재발급 후 refresh token 과 함께 반환

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 