### PR TITLE
feat : 카카오 로그인 API

### DIFF
--- a/src/main/java/com/zerobase/hoops/config/WebSecurityConfig.java
+++ b/src/main/java/com/zerobase/hoops/config/WebSecurityConfig.java
@@ -6,12 +6,12 @@ import org.springframework.beans.factory.annotation.Configurable;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
 import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
@@ -43,11 +43,11 @@ public class WebSecurityConfig {
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
         )
         .headers(header -> header
-            .frameOptions(options -> options.disable()))
+            .frameOptions(FrameOptionsConfig::disable))
         .authorizeHttpRequests(request -> request
-            .requestMatchers("/", "/api/user/**",
+            .requestMatchers("/**", "/api/user/**",
                 "/swagger-ui/**", "/v3/api-docs/**",
-                "/api/auth/login",
+                "/api/auth/login", "/api/oauth2/**/**",
                 "/api/game-user/**",
                 //로그인 개발되면 해당 부분 삭제
                 "/ws",
@@ -90,8 +90,6 @@ public class WebSecurityConfig {
   public AuthenticationManager authenticationManager(
       AuthenticationConfiguration authenticationConfiguration)
       throws Exception {
-    ProviderManager auth =
-        (ProviderManager) authenticationConfiguration.getAuthenticationManager();
-    return auth;
+    return authenticationConfiguration.getAuthenticationManager();
   }
 }

--- a/src/main/java/com/zerobase/hoops/users/dto/KakaoDto.java
+++ b/src/main/java/com/zerobase/hoops/users/dto/KakaoDto.java
@@ -1,0 +1,95 @@
+package com.zerobase.hoops.users.dto;
+
+import com.zerobase.hoops.entity.UserEntity;
+import com.zerobase.hoops.users.type.GenderType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public class KakaoDto {
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class Request {
+
+    @NotBlank(message = "아이디를 입력하세요.")
+    private String id;
+
+    @NotBlank(message = "이메일을 입력하세요.")
+    @Email(message = "이메일 형식에 맞게 입력하세요.")
+    private String email;
+
+    @NotBlank(message = "이름을 입력하세요.")
+    private String name;
+
+    @NotBlank(message = "성별을 선택하세요.")
+    private String gender;
+
+    @NotBlank(message = "별명을 입력하세요.")
+    private String nickName;
+
+    public static UserEntity toEntity(Request request) {
+      BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+      return UserEntity.builder()
+          .id(request.getId())
+          .password(encoder.encode("kakao"))
+          .email(request.getEmail())
+          .name(request.getName())
+          .birthday(LocalDate.now())
+          .gender(GenderType.valueOf(request.getGender()))
+          .nickName(request.getNickName())
+          .roles(new ArrayList<>(List.of(("ROLE_USER"))))
+          .emailAuth(true)
+          .build();
+    }
+  }
+
+  @Getter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder
+  public static class Response {
+
+    private Long userId;
+    private String id;
+    private String email;
+    private String name;
+    private LocalDate birthday;
+    private String gender;
+    private String nickName;
+    private LocalDateTime crateDate;
+    private String playStyle;
+    private String ability;
+    private List<String> roles;
+    private String refreshToken;
+
+    public static Response fromDto(UserDto userDto, String refreshToken) {
+      return Response.builder()
+          .userId(userDto.getUserId())
+          .id(userDto.getId())
+          .email(userDto.getEmail())
+          .name(userDto.getName())
+          .birthday(userDto.getBirthday())
+          .gender(userDto.getGender())
+          .nickName(userDto.getNickName())
+          .crateDate(userDto.getCreateDate())
+          .playStyle(userDto.getPlayStyle())
+          .ability(userDto.getAbility())
+          .roles(userDto.getRoles())
+          .refreshToken(refreshToken)
+          .build();
+    }
+  }
+}

--- a/src/main/java/com/zerobase/hoops/users/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/com/zerobase/hoops/users/oauth2/controller/OAuth2Controller.java
@@ -1,0 +1,48 @@
+package com.zerobase.hoops.users.oauth2.controller;
+
+import com.zerobase.hoops.users.dto.KakaoDto;
+import com.zerobase.hoops.users.dto.KakaoDto.Response;
+import com.zerobase.hoops.users.dto.TokenDto;
+import com.zerobase.hoops.users.dto.UserDto;
+import com.zerobase.hoops.users.oauth2.service.OAuthService;
+import com.zerobase.hoops.users.service.AuthService;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/oauth2")
+public class OAuth2Controller {
+
+  private final OAuthService oAuth2Service;
+  private final AuthService authService;
+
+  @GetMapping("/login/kakao")
+  public void getKakaoAuthUrl(HttpServletResponse response) throws IOException {
+    response.sendRedirect(oAuth2Service.responseUrl());
+  }
+
+  @GetMapping("/kakao")
+  public ResponseEntity<Response> kakaoLogin(
+      @RequestParam(name = "code") String code) throws IOException {
+    log.info("카카오 API 서버 code : " + code);
+    UserDto userDto = oAuth2Service.kakaoLogin(code);
+    TokenDto tokenDto = authService.getToken(userDto);
+
+    HttpHeaders responseHeaders = new HttpHeaders();
+    responseHeaders.set("Authorization", tokenDto.getAccessToken());
+
+    return ResponseEntity.ok()
+        .headers(responseHeaders)
+        .body(KakaoDto.Response.fromDto(userDto, tokenDto.getRefreshToken()));
+  }
+}

--- a/src/main/java/com/zerobase/hoops/users/oauth2/dto/KakaoOAuthTokenDto.java
+++ b/src/main/java/com/zerobase/hoops/users/oauth2/dto/KakaoOAuthTokenDto.java
@@ -1,0 +1,22 @@
+package com.zerobase.hoops.users.oauth2.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoOAuthTokenDto {
+
+  private String access_token;
+  private String token_type;
+  private String refresh_token;
+  private String id_token;
+  private Integer expires_in;
+  private String scope;
+  private Integer refresh_token_expires_in;
+
+}

--- a/src/main/java/com/zerobase/hoops/users/oauth2/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/zerobase/hoops/users/oauth2/dto/KakaoUserInfoDto.java
@@ -1,0 +1,46 @@
+package com.zerobase.hoops.users.oauth2.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class KakaoUserInfoDto {
+
+  private Long id;
+  private String connected_at;
+  private Properties properties;
+  private KakaoAccount kakao_account;
+
+  @Data
+  public static class Properties {
+
+    private String nickname;
+  }
+
+  @Data
+  public static class KakaoAccount {
+
+    private boolean profile_nickname_needs_agreement;
+    private Profile profile;
+    private boolean has_email;
+    private boolean email_needs_agreement;
+    @JsonProperty("is_email_valid")
+    private boolean is_email_valid;
+    @JsonProperty("is_email_verified")
+    private boolean is_email_verified;
+    private String email;
+    private boolean has_gender;
+    private boolean gender_needs_agreement;
+    private String gender;
+
+    @Data
+    public static class Profile {
+
+      @JsonProperty("is_default_nickname")
+      private boolean is_default_nickname;
+      private String nickname;
+
+    }
+  }
+
+}

--- a/src/main/java/com/zerobase/hoops/users/oauth2/service/OAuthService.java
+++ b/src/main/java/com/zerobase/hoops/users/oauth2/service/OAuthService.java
@@ -1,0 +1,132 @@
+package com.zerobase.hoops.users.oauth2.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.hoops.users.dto.KakaoDto;
+import com.zerobase.hoops.users.dto.LogInDto;
+import com.zerobase.hoops.users.dto.UserDto;
+import com.zerobase.hoops.users.oauth2.dto.KakaoOAuthTokenDto;
+import com.zerobase.hoops.users.oauth2.dto.KakaoUserInfoDto;
+import com.zerobase.hoops.users.oauth2.dto.KakaoUserInfoDto.KakaoAccount;
+import com.zerobase.hoops.users.oauth2.dto.KakaoUserInfoDto.Properties;
+import com.zerobase.hoops.users.repository.UserRepository;
+import com.zerobase.hoops.users.service.AuthService;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthService {
+
+  private final UserRepository userRepository;
+  private final AuthService authService;
+
+  @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+  String clientId;
+  @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+  String clientSecret;
+  @Value("${spring.security.oauth2.client.provider.kakao.authorization-uri}")
+  String authorizationUri;
+  @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
+  String tokenRequestUri;
+
+  public String responseUrl() {
+    return authorizationUri + "?client_id=" + clientId +
+        "&redirect_uri=http://localhost:8080/api/oauth2/kakao"
+        + "&response_type=code";
+  }
+
+  public UserDto kakaoLogin(String code) throws IOException {
+    KakaoUserInfoDto kakaoUser = getKakaoUserInfoDto(code);
+    Properties properties = kakaoUser.getProperties();
+    KakaoAccount kakaoAccount = kakaoUser.getKakao_account();
+    String id = "kakao_" + kakaoUser.getId().toString();
+
+    if (!userRepository.existsByEmail(kakaoAccount.getEmail())) {
+      KakaoDto.Request user = KakaoDto.Request.builder()
+          .id(id)
+          .email(kakaoAccount.getEmail())
+          .name(properties.getNickname())
+          .nickName(properties.getNickname())
+          .gender(kakaoAccount.getGender().toUpperCase())
+          .build();
+      userRepository.save(KakaoDto.Request.toEntity(user));
+
+      LogInDto.Request logInDto = kakaoUserLogin(id);
+      return authService.logInUser(logInDto);
+    }
+    LogInDto.Request logInDto = kakaoUserLogin(id);
+    return authService.logInUser(logInDto);
+  }
+
+  private KakaoUserInfoDto getKakaoUserInfoDto(String code)
+      throws JsonProcessingException {
+    ResponseEntity<String> accessTokenResponse = requestAccessToken(code);
+    KakaoOAuthTokenDto oAuthToken = getAccessToken(accessTokenResponse);
+    ResponseEntity<String> userInfoResponse = requestUserInfo(oAuthToken);
+
+    return getUserInfo(userInfoResponse);
+  }
+
+  public ResponseEntity<String> requestAccessToken(String code) {
+    RestTemplate restTemplate = new RestTemplate();
+    HttpHeaders headersAccess = new HttpHeaders();
+    headersAccess.add("Content-type", "application/x-www-form-urlencoded;"
+        + "charset=utf-8");
+
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    params.add("grant_type", "authorization_code");
+    params.add("client_id", clientId);
+    params.add("client_secret", clientSecret);
+    params.add("redirect_uri", "http://localhost:8080/api/oauth2/kakao");
+    params.add("code", code);
+
+    HttpEntity<MultiValueMap<String, String>> kakaoRequest =
+        new HttpEntity<>(params, headersAccess);
+
+    return restTemplate.postForEntity(tokenRequestUri, kakaoRequest,
+        String.class);
+  }
+
+  public KakaoOAuthTokenDto getAccessToken(ResponseEntity<String> response)
+      throws JsonProcessingException {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    return objectMapper.readValue(response.getBody(), KakaoOAuthTokenDto.class);
+  }
+
+  public ResponseEntity<String> requestUserInfo(
+      KakaoOAuthTokenDto oAuthTokenDto) {
+    HttpHeaders headers = new HttpHeaders();
+    RestTemplate restTemplate = new RestTemplate();
+    headers.add("Authorization", "Bearer " + oAuthTokenDto.getAccess_token());
+
+    HttpEntity<MultiValueMap<String, String>> request =
+        new HttpEntity<>(headers);
+
+    return restTemplate.exchange("https://kapi"
+        + ".kakao.com/v2/user/me", HttpMethod.GET, request, String.class);
+  }
+
+  public KakaoUserInfoDto getUserInfo(ResponseEntity<String> response)
+      throws JsonProcessingException {
+    ObjectMapper objectMapper = new ObjectMapper();
+    return objectMapper.readValue(response.getBody(), KakaoUserInfoDto.class);
+  }
+
+  public LogInDto.Request kakaoUserLogin(String id) {
+    return LogInDto.Request.builder()
+        .id(id)
+        .password("kakao")
+        .build();
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,17 +47,19 @@ spring:
   security:
     oauth2:
       client:
+        registration:
+          kakao:
+            client-id: 81ff5d41b61bd9fdbe010bdfe3dfa84c
+            client-secret: pXOElpX2yNj2uWcAzEHoXdDNIUuVs7Ft
+            redirect-uri: '{baseUrl}/api/oauth2/{registrationId}'
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+            scope: profile_nickname, account_email, gender, birthday
+            client-name: Kakao
+
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
-        registration:
-          kakao:
-            client-id: 55b59bda35128367ab07058375e739dc
-            client-secret: RW23N898usWAcY98LEc5A2H7wR5mBAmQ
-            redirect-uri: '{baseUrl}/oauth2/callback/{registrationId}'
-            authorization-grant-type: authorization_code
-            client-authentication-method: client_secret_post
-            scope: profile_nickname

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,1 @@
+<a href="http://localhost:8080/api/oauth2/login/kakao">Kakao Login</a><br>


### PR DESCRIPTION
### 변경사항
**TO-BE**
 - 카카오 로그인 API 구현
	 - 카카오 회원 로그인 시 카카오 서버로부터 인가 코드 발급 요청
	 - 동의 화면 진행 후 302 Redirect URI 로 인가 코드 전달
	 - 해당 코드로 토큰 발급
	 - 발급 받은 토큰으로 사용자 정보 조회
	 - 최초 로그인 시 가입 처리 후 로그인 처리 (access token, refresh token 발급)
	 - 기 로그인 회원인 경우 토큰만 발급

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 