### PR TITLE
[리펙토링] 경기 참여 목록 조회 / 지난 경기 조회 / 메인 페이지 게임 조회

### DIFF
--- a/src/main/java/com/zerobase/hoops/gameUsers/controller/GameUserController.java
+++ b/src/main/java/com/zerobase/hoops/gameUsers/controller/GameUserController.java
@@ -10,6 +10,7 @@ import com.zerobase.hoops.gameUsers.dto.UserJoinsGameDto;
 import com.zerobase.hoops.gameUsers.service.GameUserService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -35,15 +36,17 @@ public class GameUserController {
   private final GameUserService gameUserService;
 
   @GetMapping("/search")
-  public ResponseEntity<List<GameSearchResponse>> findFilteredGames(
+  public ResponseEntity<Page<GameSearchResponse>> findFilteredGames(
       @RequestParam(required = false) LocalDate localDate,
       @RequestParam(required = false) CityName cityName,
       @RequestParam(required = false) FieldStatus fieldStatus,
       @RequestParam(required = false) Gender gender,
-      @RequestParam(required = false) MatchFormat matchFormat) {
+      @RequestParam(required = false) MatchFormat matchFormat,
+      @Positive @RequestParam int page,
+      @Positive @RequestParam int size) {
     return ResponseEntity.ok(
         gameUserService.findFilteredGames(localDate,
-            cityName, fieldStatus, gender, matchFormat));
+            cityName, fieldStatus, gender, matchFormat, page, size));
   }
 
   @GetMapping("/search-address")
@@ -61,17 +64,21 @@ public class GameUserController {
   }
 
   @PreAuthorize("hasRole('USER')")
-  @GetMapping("/my-current-game-list/{size}")
+  @GetMapping("/my-current-game-list")
   public ResponseEntity<Page<GameSearchResponse>> myCurrentGameList(
-      @PathVariable int size) {
-    return ResponseEntity.ok(gameUserService.myCurrentGameList(size));
+      @Positive @RequestParam int page,
+      @Positive @RequestParam int size) {
+    return ResponseEntity.ok(
+        gameUserService.myCurrentGameList(page, size));
   }
 
   @PreAuthorize("hasRole('USER')")
   @GetMapping("/my-last-game-list")
-  public ResponseEntity<List<GameSearchResponse>> myLastGameList() {
-    return ResponseEntity.ok(gameUserService.myLastGameList());
+  public ResponseEntity<Page<GameSearchResponse>> myLastGameList(
+      @Positive @RequestParam int page,
+      @Positive @RequestParam int size) {
+    return ResponseEntity.ok(gameUserService.myLastGameList(page, size));
   }
 
-  // 유저목록 불러오기
+
 }

--- a/src/main/java/com/zerobase/hoops/gameUsers/dto/ParticipateGameDto.java
+++ b/src/main/java/com/zerobase/hoops/gameUsers/dto/ParticipateGameDto.java
@@ -33,7 +33,6 @@ public class ParticipateGameDto {
 
   public static ParticipateGameDto fromEntity(
       ParticipantGameEntity participantGameEntity) {
-
     return ParticipateGameDto.builder()
         .participantId(participantGameEntity.getParticipantId())
         .status(participantGameEntity.getStatus())

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -57,11 +57,11 @@ VALUES
 
 INSERT INTO game (game_id, title, content, head_count, field_status, gender, start_date_time, created_date_time, deleted_date_time, invite_yn, address,latitude,longitude, city_name, match_format, user_id)
 VALUES
-(5, 'Example Game', 'This is an example game content.', 10, 'INDOOR', 'MALEONLY', '2024-05-04 10:00:00', '2024-05-04 08:00:00', NULL, TRUE, '인천 문학 경기장2',1.0, 1.0, 'SEOUL', 'FIVEONFIVE', 4);
+(5, 'Example Game', 'This is an example game content.', 10, 'INDOOR', 'MALEONLY', '2024-05-12 10:00:00', '2024-05-04 08:00:00', NULL, TRUE, '인천 문학 경기장2',1.0, 1.0, 'SEOUL', 'FIVEONFIVE', 4);
 
 INSERT INTO game (game_id, title, content, head_count, field_status, gender, start_date_time, created_date_time, deleted_date_time, invite_yn, address, latitude,longitude,city_name, match_format, user_id)
 VALUES
-(6, 'Example Game', 'This is an example game content 2.', 10, 'INDOOR', 'MALEONLY', '2024-05-08 10:00:00', '2024-05-08 08:00:00', NULL, TRUE, '서울 abc 경기장',1.0, 1.0, 'SEOUL', 'THREEONTHREE', 2);
+(6, 'Example Game', 'This is an example game content 2.', 10, 'INDOOR', 'MALEONLY', '2024-05-11 10:00:00', '2024-05-08 08:00:00', NULL, TRUE, '서울 abc 경기장',1.0, 1.0, 'SEOUL', 'THREEONTHREE', 2);
 
 INSERT INTO game (game_id, title, content, head_count, field_status, gender, start_date_time, created_date_time, deleted_date_time, invite_yn, address, latitude,longitude,city_name, match_format, user_id)
 VALUES
@@ -70,7 +70,7 @@ VALUES
 
 INSERT INTO game (game_id, title, content, head_count, field_status, gender, start_date_time, created_date_time, deleted_date_time, invite_yn, address, latitude,longitude,city_name, match_format, user_id)
 VALUES
-(7, 'Example Game', 'This is an example game content 3.', 10, 'INDOOR', 'MALEONLY', '2024-05-10 11:00:00', '2024-05-07 08:00:00', NULL, TRUE, '인천 문학 경기장',1.0, 1.0, 'SEOUL', 'FIVEONFIVE', 3);
+(7, 'Example Game', 'This is an example game content 3.', 10, 'INDOOR', 'MALEONLY', '2024-05-15 11:00:00', '2024-05-07 08:00:00', NULL, TRUE, '인천 문학 경기장',1.0, 1.0, 'SEOUL', 'FIVEONFIVE', 3);
 
 
 INSERT INTO game (game_id, title, content, head_count, field_status, gender, start_date_time, created_date_time, deleted_date_time, invite_yn, address, latitude,longitude,city_name, match_format, user_id)
@@ -109,10 +109,11 @@ VALUES
     (29, 'APPLY', '2024-05-06T10:00:00', null,null,null,null,null,null, 4, 6),
     (30, 'APPLY', '2024-05-06T10:00:00', null,null,null,null,null,null, 4, 7),
     (31, 'APPLY', '2024-05-06T10:00:00', null,null,null,null,null,null, 4, 8),
-    (32, 'ACCEPT', '2024-05-06T10:00:00', null,null,null,null,null,null, 7, 1),
-    (33, 'ACCEPT', '2024-05-06T10:00:00', null,null,null,null,null,null, 7, 2),
-    (34, 'ACCEPT', '2024-05-06T10:00:00', null,null,null,null,null,null, 7, 3),
-    (35, 'ACCEPT', '2024-05-06T10:00:00', null,null,null,null,null,null, 7, 4),
-    (36, 'ACCEPT', '2024-05-06T10:00:00', null,null,null,null,null,null, 7, 5),
-    (37, 'ACCEPT', '2024-05-06T10:00:00', null,null,null,null,null,null, 7, 6),
-    (38, 'ACCEPT', '2024-05-06T10:00:00', null,null,null,null,null,null, 7, 7);
+    (32, 'ACCEPT', '2024-05-06T10:00:00', null,null,null,null,null,null, 6, 1),
+    (33, 'ACCEPT', '2024-05-06T10:00:00', null,null,null,null,null,null, 7, 1),
+    (34, 'ACCEPT', '2024-05-06T10:00:00', null,null,null,null,null,null, 7, 2),
+    (35, 'ACCEPT', '2024-05-06T10:00:00', null,null,null,null,null,null, 7, 3),
+    (36, 'ACCEPT', '2024-05-06T10:00:00', null,null,null,null,null,null, 7, 4),
+    (37, 'ACCEPT', '2024-05-06T10:00:00', null,null,null,null,null,null, 7, 5),
+    (38, 'ACCEPT', '2024-05-06T10:00:00', null,null,null,null,null,null, 7, 6),
+    (39, 'ACCEPT', '2024-05-06T10:00:00', null,null,null,null,null,null, 7, 7);

--- a/src/test/java/com/zerobase/hoops/gameUsers/controller/GameUserControllerTest.java
+++ b/src/test/java/com/zerobase/hoops/gameUsers/controller/GameUserControllerTest.java
@@ -85,7 +85,6 @@ class GameUserControllerTest {
     FieldStatus fieldStatus = FieldStatus.INDOOR;
     Gender gender = Gender.ALL;
     MatchFormat matchFormat = MatchFormat.THREEONTHREE;
-    int size = 3;
 
     LocalDateTime time = LocalDateTime.now()
         .plusDays(10);
@@ -114,11 +113,13 @@ class GameUserControllerTest {
     Page<GameSearchResponse> expectedPage = new PageImpl<>(gameSearchResponses);
 
     // When
-    when(gameUserService.myCurrentGameList(size)).thenReturn(
+    when(gameUserService.myCurrentGameList(1,1)).thenReturn(
         (expectedPage));
 
     // Then
-    mockMvc.perform(get("/api/game-user/my-current-game-list/{size}", size)
+    mockMvc.perform(get("/api/game-user/my-current-game-list")
+            .param("page", "1")
+            .param("size", "1")
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andDo(print())
@@ -161,18 +162,20 @@ class GameUserControllerTest {
     gameEntity.setUserEntity(userEntity);
     List<GameSearchResponse> gameSearchResponses = Arrays.asList(
         GameSearchResponse.of(gameEntity, userEntity.getUserId()));
-
+    Page<GameSearchResponse> expectedPage = new PageImpl<>(gameSearchResponses);
     // When
-    when(gameUserService.myLastGameList()).thenReturn(gameSearchResponses);
+    when(gameUserService.myLastGameList(1,1)).thenReturn(expectedPage);
 
     // Then
     mockMvc.perform(get("/api/game-user/my-last-game-list")
+            .param("page", "1")
+            .param("size", "1")
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andDo(print())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$[0].gameId").value(gameEntity.getGameId()))
-        .andExpect(jsonPath("$").isArray());
+        .andExpect(jsonPath("$.content[0].gameId").value(gameEntity.getGameId()))
+        .andExpect(jsonPath("$.content").isArray());
   }
 
   @DisplayName("게임 참가 요청 성공")
@@ -224,10 +227,10 @@ class GameUserControllerTest {
 
     List<GameSearchResponse> gameSearchResponses = Arrays.asList(
         GameSearchResponse.of(gameEntity, userEntity.getUserId()));
-
+    Page<GameSearchResponse> expectedPage = new PageImpl<>(gameSearchResponses);
     // When
     when(gameUserService.findFilteredGames(any(), any(), any(),
-        any(), any())).thenReturn(gameSearchResponses);
+        any(), any(), eq(1), eq(1))).thenReturn(expectedPage);
 
     // Then
     mockMvc.perform(get("/api/game-user/search")
@@ -236,11 +239,13 @@ class GameUserControllerTest {
             .param("fieldStatus", fieldStatus.toString())
             .param("gender", gender.toString())
             .param("matchFormat", matchFormat.toString())
+            .param("page", "1")
+            .param("size", "1")
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andDo(print())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$").isArray());
+        .andExpect(jsonPath("$.content").isArray());
   }
 
   @DisplayName("필터 검색 데이터 테스트")
@@ -277,11 +282,12 @@ class GameUserControllerTest {
     gameEntity.setUserEntity(userEntity);
     List<GameSearchResponse> expectedGames = Arrays.asList(
         GameSearchResponse.of(gameEntity, userEntity.getUserId()));
+    Page<GameSearchResponse> expectedPage = new PageImpl<>(expectedGames);
 
     // When
     when(gameUserService.findFilteredGames(eq(localDate), eq(cityName),
-        eq(fieldStatus), eq(gender), eq(matchFormat)))
-        .thenReturn(expectedGames);
+        eq(fieldStatus), eq(gender), eq(matchFormat),eq(1),eq(1)))
+        .thenReturn(expectedPage);
 
     // Then
     mockMvc.perform(get("/api/game-user/search")
@@ -290,31 +296,23 @@ class GameUserControllerTest {
             .param("fieldStatus", fieldStatus.name())
             .param("gender", gender.name())
             .param("matchFormat", matchFormat.name())
+            .param("page", "1")
+            .param("size", "1")
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.size()").value(expectedGames.size()))
-        .andExpect(jsonPath("$[0].gameId").value(gameEntity.getGameId()))
-        .andExpect(jsonPath("$[0].title").value(gameEntity.getTitle()))
-        .andExpect(jsonPath("$[0].content").value(gameEntity.getContent()))
-        .andExpect(
-            jsonPath("$[0].headCount").value(gameEntity.getHeadCount()))
-        .andExpect(jsonPath("$[0].fieldStatus").value(
-            gameEntity.getFieldStatus().name()))
-        .andExpect(
-            jsonPath("$[0].gender").value(gameEntity.getGender().name()))
-        .andExpect(jsonPath("$[0].startDateTime").value(
-            gameEntity.getStartDateTime().toString()))
-        .andExpect(
-            jsonPath("$[0].inviteYn").value(gameEntity.getInviteYn()))
-        .andExpect(jsonPath("$[0].address").value(gameEntity.getAddress()))
-        .andExpect(
-            jsonPath("$[0].latitude").value(gameEntity.getLatitude()))
-        .andExpect(
-            jsonPath("$[0].longitude").value(gameEntity.getLongitude()))
-        .andExpect(jsonPath("$[0].cityName").value(
-            gameEntity.getCityName().name()))
-        .andExpect(jsonPath("$[0].matchFormat").value(
-            gameEntity.getMatchFormat().name()));
+        .andExpect(jsonPath("$.content[0].gameId").value(gameEntity.getGameId()))
+        .andExpect(jsonPath("$.content[0].title").value(gameEntity.getTitle()))
+        .andExpect(jsonPath("$.content[0].content").value(gameEntity.getContent()))
+        .andExpect(jsonPath("$.content[0].headCount").value(gameEntity.getHeadCount()))
+        .andExpect(jsonPath("$.content[0].fieldStatus").value(gameEntity.getFieldStatus().name()))
+        .andExpect(jsonPath("$.content[0].gender").value(gameEntity.getGender().name()))
+        .andExpect(jsonPath("$.content[0].startDateTime").value(gameEntity.getStartDateTime().toString()))
+        .andExpect(jsonPath("$.content[0].inviteYn").value(gameEntity.getInviteYn()))
+        .andExpect(jsonPath("$.content[0].address").value(gameEntity.getAddress()))
+        .andExpect(jsonPath("$.content[0].latitude").value(gameEntity.getLatitude()))
+        .andExpect(jsonPath("$.content[0].longitude").value(gameEntity.getLongitude()))
+        .andExpect(jsonPath("$.content[0].cityName").value(gameEntity.getCityName().name()))
+        .andExpect(jsonPath("$.content[0].matchFormat").value(gameEntity.getMatchFormat().name()));
   }
 
   @DisplayName("주소 검색 테스트")

--- a/src/test/java/com/zerobase/hoops/gameUsers/service/GameUserServiceTest.java
+++ b/src/test/java/com/zerobase/hoops/gameUsers/service/GameUserServiceTest.java
@@ -99,7 +99,8 @@ class GameUserServiceTest {
     when(gameCheckOutRepository.findByUserEntity_UserIdAndStatus(
         user.getUserId(), ParticipantGameStatus.ACCEPT))
         .thenReturn(java.util.Optional.of(userGameList));
-    Page<GameSearchResponse> result = gameUserService.myCurrentGameList(1);
+    Page<GameSearchResponse> result = gameUserService.myCurrentGameList(1,
+        1);
     List<GameSearchResponse> result2 = result.getContent();
 
     // Then
@@ -139,6 +140,7 @@ class GameUserServiceTest {
         jwtTokenExtractMock);
     int pageSize = 10;
     Page<GameSearchResponse> resultPage = gameUserService.myCurrentGameList(
+        1,
         pageSize);
     List<GameSearchResponse> result = resultPage.getContent();
 
@@ -166,10 +168,10 @@ class GameUserServiceTest {
         user.getUserId(),
         ParticipantGameStatus.ACCEPT))
         .thenReturn(java.util.Optional.of(userGameList));
-    List<GameSearchResponse> result = gameUserService.myLastGameList();
-
+    Page<GameSearchResponse> result = gameUserService.myLastGameList(1, 1);
+    List<GameSearchResponse> result2 = result.getContent();
     // Then
-    assertEquals(1, result.size());
+    assertEquals(1, result2.size());
   }
 
   @Test
@@ -238,12 +240,12 @@ class GameUserServiceTest {
     when(gameUserRepository.findAll(any(Specification.class))).thenReturn(
         gameEntities);
 
-    List<GameSearchResponse> result = gameUserService.findFilteredGames(
-        null,
-        null, null, null, null);
-
+    Page<GameSearchResponse> result = gameUserService.findFilteredGames(
+        null, null, null, null, null
+        , 1, 2);
+    List<GameSearchResponse> result2 = result.getContent();
     // Then
-    assertEquals(gameEntities.size(), result.size());
+    assertEquals(gameEntities.size(), result2.size());
   }
 
   @Test
@@ -271,12 +273,12 @@ class GameUserServiceTest {
     when(gameUserRepository.findAll(any(Specification.class))).thenReturn(
         gameEntities);
 
-    List<GameSearchResponse> result = gameUserService.findFilteredGames(
-        date,
-        cityName, fieldStatus, gender, matchFormat);
+    Page<GameSearchResponse> result = gameUserService.findFilteredGames(
+        date, cityName, fieldStatus, gender, matchFormat, 1, 2);
+    List<GameSearchResponse> result2 = result.getContent();
 
     // Then
-    assertEquals(gameEntities.size(), result.size());
+    assertEquals(gameEntities.size(), result2.size());
   }
 
   @Test


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 현재 참여하는 경기를 조회할시 size 만으로 계산되어 page를 조회할 수 있는 인덱스가 없다 
- 지난 경기 리스트 -> 페이징 처리 x
- 메인 페이지의 경기 리스트 -> 페이징 처리 x

**TO-BE**
- 지난 경기 리스트, 현재 참여하고 있는 경기리스트, 메인 페이지 경기리스트 => 페이징 처리

- page + size 받을 수 있게 처리
- 실제 데이터보다 더 많은 page 처리를 입력할 경우 가장 마지막 페이지로 처리
  - totalSize = 게임 리스트의 전체 크기
  - totalPages = 전체 페이지 수 -> 전체 게임 수 / 페이지 + 올림계산
  - page = Math.min(page, lastPage)
    - 페이지가 넘어가지 않도록 방지 -> 현재 페이지 번호를 마지막 페이지 번호와 비교해 더 작은 현재 페이지 번호를 설정
  - start = 현재 페이지의 시작 인덱스 -> 페이지 번호에 따라 시작 인덱스 결정
  - end = 현재 페이지의 끝 인덱스 -> 현재 페이지의 마지막 게임이 있는 인덱스, 페이지 번호에 따라 결정
  
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [o] 테스트 코드
- [o] API 테스트 