### PR TITLE
feat : 회원 정보 조회 및 수정

### DIFF
--- a/src/main/java/com/zerobase/hoops/entity/UserEntity.java
+++ b/src/main/java/com/zerobase/hoops/entity/UserEntity.java
@@ -1,5 +1,6 @@
 package com.zerobase.hoops.entity;
 
+import com.zerobase.hoops.users.dto.EditDto;
 import com.zerobase.hoops.users.type.AbilityType;
 import com.zerobase.hoops.users.type.GenderType;
 import com.zerobase.hoops.users.type.PlayStyleType;
@@ -97,6 +98,27 @@ public class UserEntity implements UserDetails {
   public void passwordEdit(String password) {
     if (!password.isEmpty()) {
       this.password = password;
+    }
+  }
+
+  public void edit(EditDto.Request request) {
+    if (request.getName() != null) {
+      this.name = request.getName();
+    }
+    if (request.getNickName() != null) {
+      this.nickName = request.getNickName();
+    }
+    if (request.getBirthday() != null) {
+      this.birthday = request.getBirthday();
+    }
+    if (request.getGender() != null) {
+      this.gender = GenderType.valueOf(request.getGender());
+    }
+    if (request.getPlayStyle() != null) {
+      this.playStyle = PlayStyleType.valueOf(request.getPlayStyle());
+    }
+    if (request.getAbility() != null) {
+      this.ability = AbilityType.valueOf(request.getAbility());
     }
   }
 

--- a/src/main/java/com/zerobase/hoops/users/controller/AuthController.java
+++ b/src/main/java/com/zerobase/hoops/users/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.zerobase.hoops.users.controller;
 
 import com.zerobase.hoops.entity.UserEntity;
+import com.zerobase.hoops.users.dto.EditDto;
 import com.zerobase.hoops.users.dto.LogInDto;
 import com.zerobase.hoops.users.dto.LogInDto.Response;
 import com.zerobase.hoops.users.dto.TokenDto;
@@ -17,6 +18,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -84,5 +87,40 @@ public class AuthController {
     authService.logOutUser(request, userEntity);
 
     return ResponseEntity.ok(HttpStatus.OK);
+  }
+
+  /**
+   * 회원 정보 조회
+   */
+  @Operation(summary = "회원 정보 조회")
+  @GetMapping("/user/info")
+  public ResponseEntity<UserDto> getUserInfo(
+      HttpServletRequest request,
+      @AuthenticationPrincipal UserEntity user
+  ) {
+    UserDto userDto = authService.getUserInfo(request, user);
+
+    return ResponseEntity.ok(userDto);
+  }
+
+  /**
+   * 회원 정보 수정
+   */
+  @Operation(summary = "회원 정보 수정")
+  @PatchMapping("/user/edit")
+  public ResponseEntity<EditDto.Response> editUserInfo(
+      HttpServletRequest request,
+      @RequestBody @Validated EditDto.Request editDto,
+      @AuthenticationPrincipal UserEntity user
+  ) {
+    UserDto userDto = authService.editUserInfo(request, editDto, user);
+    TokenDto tokenDto = authService.getToken(userDto);
+
+    HttpHeaders responseHeaders = new HttpHeaders();
+    responseHeaders.set("Authorization", tokenDto.getAccessToken());
+
+    return ResponseEntity.ok()
+        .headers(responseHeaders)
+        .body(EditDto.Response.fromDto(userDto, tokenDto.getRefreshToken()));
   }
 }

--- a/src/main/java/com/zerobase/hoops/users/dto/EditDto.java
+++ b/src/main/java/com/zerobase/hoops/users/dto/EditDto.java
@@ -1,0 +1,80 @@
+package com.zerobase.hoops.users.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Pattern;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class EditDto {
+
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Builder
+  public static class Request {
+
+    private String name;
+    private String nickName;
+
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[~!@#$%^&*()])"
+        + "[a-zA-Z0-9~!@#$%^&*()]{8,13}$")
+    private String password;
+
+    @JsonFormat(shape = Shape.STRING,
+        pattern = "yyyyMMdd",
+        timezone = "Asia/Seoul")
+    @Past(message = "생년월일은 과거의 날짜만 입력 가능합니다.")
+    private LocalDate birthday;
+
+    private String gender;
+    private String playStyle;
+    private String ability;
+  }
+
+  @Getter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder
+  public static class Response {
+
+    private Long userId;
+    private String id;
+    private String email;
+    private String name;
+    private LocalDate birthday;
+    private String gender;
+    private String nickName;
+    private LocalDateTime crateDate;
+    private String playStyle;
+    private String ability;
+    private List<String> roles;
+    private String refreshToken;
+
+    public static Response fromDto(UserDto userDto, String refreshToken) {
+      return Response.builder()
+          .userId(userDto.getUserId())
+          .id(userDto.getId())
+          .email(userDto.getEmail())
+          .name(userDto.getName())
+          .birthday(userDto.getBirthday())
+          .gender(userDto.getGender())
+          .nickName(userDto.getNickName())
+          .crateDate(userDto.getCreateDate())
+          .playStyle(userDto.getPlayStyle())
+          .ability(userDto.getAbility())
+          .roles(userDto.getRoles())
+          .refreshToken(refreshToken)
+          .build();
+    }
+  }
+
+}

--- a/src/main/java/com/zerobase/hoops/users/dto/EditDto.java
+++ b/src/main/java/com/zerobase/hoops/users/dto/EditDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -22,7 +23,9 @@ public class EditDto {
   @Builder
   public static class Request {
 
+    @Size(min = 2)
     private String name;
+    @Size(min = 2)
     private String nickName;
 
     @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[~!@#$%^&*()])"


### PR DESCRIPTION
### 변경사항
**AS-IS**

**TO-BE**
 - 회원 정보 조회
	 - 로그인 되어 있는 회원의 토큰 인증 정보로 조회

 - 회원 정보 수정
	 - 수정 가능 항목 : 이름, 비밀번호, 별명, 생년월일, 성별, 플레이 스타일, 자신있는 능력
	 - 입력한 값만 업데이트
	 - 비밀번호 입력 시 암호화 후 저장

### 테스트
- [x] 테스트 코드
- [x] API 테스트 