### PR TITLE
fix : 비밀번호 찾기 진행 후 로그인 시 형식 에러 발생 수정

### DIFF
--- a/src/main/java/com/zerobase/hoops/users/controller/UserController.java
+++ b/src/main/java/com/zerobase/hoops/users/controller/UserController.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -109,7 +108,7 @@ public class UserController {
    * 비밀번호 찾기
    */
   @Operation(summary = "비밀번호 찾기")
-  @PatchMapping("/find/password")
+  @GetMapping("/find/password")
   public ResponseEntity<Boolean> findPassword(
       @RequestParam(name = "id") String id
   ) throws NoSuchAlgorithmException {

--- a/src/main/java/com/zerobase/hoops/users/service/UserService.java
+++ b/src/main/java/com/zerobase/hoops/users/service/UserService.java
@@ -188,7 +188,8 @@ public class UserService implements UserDetailsService {
         userRepository.findById(id)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-    String newPassword = CertificationProvider.createCertificationNumber();
+    String newPassword =
+        "Gnqtm!" + CertificationProvider.createCertificationNumber();
     String encodedNewPassword = passwordEncoder.encode(newPassword);
     user.passwordEdit(encodedNewPassword);
     userRepository.save(user);


### PR DESCRIPTION
### 변경사항
**AS-IS**
 - 비밀번호 찾기 @PatchMapping
 - 비밀번호 찾기 비밀번호 난수만 메일로 전송

**TO-BE**
 - 비밀번호 찾기 @GetMapping
 - 비밀번호 찾기 비밀번호에 "Gnqtm!" 추가하여 전송받은 비밀번호로 로그인 시 에러 발생하지 않음

### 테스트
- [x] 테스트 코드
- [x] API 테스트 