### PR TITLE
[기능 추가] 매너포인트 유저 목록 조회

### DIFF
--- a/src/main/java/com/zerobase/hoops/entity/MannerPointEntity.java
+++ b/src/main/java/com/zerobase/hoops/entity/MannerPointEntity.java
@@ -1,0 +1,45 @@
+package com.zerobase.hoops.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Builder
+@Entity
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "manner_point")
+public class MannerPointEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(nullable = false)
+  private Long id;
+
+  private int point;
+
+  @ManyToOne
+  private UserEntity user;
+
+  @ManyToOne
+  private UserEntity receiver;
+
+  @CreatedDate
+  private LocalDateTime createdDateTime;
+
+}

--- a/src/main/java/com/zerobase/hoops/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/hoops/exception/ErrorCode.java
@@ -75,6 +75,9 @@ public enum ErrorCode {
   NOT_FOUND_APPLY_FRIEND(HttpStatus.BAD_REQUEST.value(), "친구 신청한 상태가 아닙니다."),
   NOT_FOUND_ACCEPT_FRIEND(HttpStatus.BAD_REQUEST.value(), "친구 수락한 상태가 아닙니다."),
 
+  // 매너점수
+  INVALID_GAME_ID(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 game_id입니다."),
+
   // 서버 오류
   INTERNAL_SERVER_ERROR(HttpStatus.BAD_REQUEST.value(),"내부 서버 오류");
 

--- a/src/main/java/com/zerobase/hoops/gameUsers/controller/GameUserController.java
+++ b/src/main/java/com/zerobase/hoops/gameUsers/controller/GameUserController.java
@@ -1,23 +1,28 @@
 
 package com.zerobase.hoops.gameUsers.controller;
 
+import com.zerobase.hoops.entity.ParticipantGameEntity;
 import com.zerobase.hoops.gameCreator.type.CityName;
 import com.zerobase.hoops.gameCreator.type.FieldStatus;
 import com.zerobase.hoops.gameCreator.type.Gender;
 import com.zerobase.hoops.gameCreator.type.MatchFormat;
 import com.zerobase.hoops.gameUsers.dto.GameSearchResponse;
+import com.zerobase.hoops.gameUsers.dto.MannerPointListResponse;
 import com.zerobase.hoops.gameUsers.dto.UserJoinsGameDto;
 import com.zerobase.hoops.gameUsers.service.GameUserService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -80,5 +85,11 @@ public class GameUserController {
     return ResponseEntity.ok(gameUserService.myLastGameList(page, size));
   }
 
+  @PreAuthorize("hasRole('USER')")
+  @GetMapping("/manner-point/{gameId}")
+  public ResponseEntity<List<MannerPointListResponse>> getMannerPoint(
+      @PathVariable("gameId") @NotBlank String gameId){
+    return ResponseEntity.ok(gameUserService.getMannerPoint(gameId));
+  }
 
 }

--- a/src/main/java/com/zerobase/hoops/gameUsers/controller/GameUserController.java
+++ b/src/main/java/com/zerobase/hoops/gameUsers/controller/GameUserController.java
@@ -1,7 +1,6 @@
 
 package com.zerobase.hoops.gameUsers.controller;
 
-import com.zerobase.hoops.entity.ParticipantGameEntity;
 import com.zerobase.hoops.gameCreator.type.CityName;
 import com.zerobase.hoops.gameCreator.type.FieldStatus;
 import com.zerobase.hoops.gameCreator.type.Gender;
@@ -16,13 +15,11 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -88,7 +85,7 @@ public class GameUserController {
   @PreAuthorize("hasRole('USER')")
   @GetMapping("/manner-point/{gameId}")
   public ResponseEntity<List<MannerPointListResponse>> getMannerPoint(
-      @PathVariable("gameId") @NotBlank String gameId){
+      @PathVariable("gameId") @NotBlank String gameId) {
     return ResponseEntity.ok(gameUserService.getMannerPoint(gameId));
   }
 

--- a/src/main/java/com/zerobase/hoops/gameUsers/dto/MannerPointListResponse.java
+++ b/src/main/java/com/zerobase/hoops/gameUsers/dto/MannerPointListResponse.java
@@ -12,6 +12,7 @@ public class MannerPointListResponse {
   private String title;
   private String address;
   private String player;
+  private Long playerId;
 
   public static MannerPointListResponse of(
       ParticipantGameEntity participantGame) {
@@ -20,6 +21,7 @@ public class MannerPointListResponse {
         .title(participantGame.getGameEntity().getTitle())
         .address(participantGame.getGameEntity().getAddress())
         .player(participantGame.getUserEntity().getNickName())
+        .playerId(participantGame.getUserEntity().getUserId())
         .build();
   }
 }

--- a/src/main/java/com/zerobase/hoops/gameUsers/dto/MannerPointListResponse.java
+++ b/src/main/java/com/zerobase/hoops/gameUsers/dto/MannerPointListResponse.java
@@ -1,8 +1,6 @@
 package com.zerobase.hoops.gameUsers.dto;
 
-import com.zerobase.hoops.entity.GameEntity;
 import com.zerobase.hoops.entity.ParticipantGameEntity;
-import com.zerobase.hoops.entity.UserEntity;
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/com/zerobase/hoops/gameUsers/dto/MannerPointListResponse.java
+++ b/src/main/java/com/zerobase/hoops/gameUsers/dto/MannerPointListResponse.java
@@ -1,0 +1,27 @@
+package com.zerobase.hoops.gameUsers.dto;
+
+import com.zerobase.hoops.entity.GameEntity;
+import com.zerobase.hoops.entity.ParticipantGameEntity;
+import com.zerobase.hoops.entity.UserEntity;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MannerPointListResponse {
+
+  private Long gameId;
+  private String title;
+  private String address;
+  private String player;
+
+  public static MannerPointListResponse of(
+      ParticipantGameEntity participantGame) {
+    return MannerPointListResponse.builder()
+        .gameId(participantGame.getGameEntity().getGameId())
+        .title(participantGame.getGameEntity().getTitle())
+        .address(participantGame.getGameEntity().getAddress())
+        .player(participantGame.getUserEntity().getNickName())
+        .build();
+  }
+}

--- a/src/main/java/com/zerobase/hoops/gameUsers/repository/GameCheckOutRepository.java
+++ b/src/main/java/com/zerobase/hoops/gameUsers/repository/GameCheckOutRepository.java
@@ -22,5 +22,11 @@ public interface GameCheckOutRepository extends
   boolean existsByGameEntity_GameIdAndUserEntity_UserId(Long gameId,
       Long userId);
 
+  Optional<List<ParticipantGameEntity>> findByStatusAndGameEntity_GameId(
+      ParticipantGameStatus status, Long gameId);
+
+  boolean existsByGameEntity_GameIdAndUserEntity_UserIdAndStatus(
+      Long gameId, Long userId, ParticipantGameStatus status);
+
 
 }

--- a/src/main/java/com/zerobase/hoops/gameUsers/repository/GameCheckOutSpecifications.java
+++ b/src/main/java/com/zerobase/hoops/gameUsers/repository/GameCheckOutSpecifications.java
@@ -1,4 +1,4 @@
-package com.zerobase.hoops.gameUsers.service;
+package com.zerobase.hoops.gameUsers.repository;
 
 import com.zerobase.hoops.entity.GameEntity;
 import com.zerobase.hoops.gameCreator.type.CityName;
@@ -8,7 +8,7 @@ import com.zerobase.hoops.gameCreator.type.MatchFormat;
 import java.time.LocalDate;
 import org.springframework.data.jpa.domain.Specification;
 
-public class GameSpecifications {
+public class GameCheckOutSpecifications {
 
   public static Specification<GameEntity> withCityName(CityName cityName) {
     return (root, query, criteriaBuilder) ->

--- a/src/main/java/com/zerobase/hoops/gameUsers/repository/GameUserRepository.java
+++ b/src/main/java/com/zerobase/hoops/gameUsers/repository/GameUserRepository.java
@@ -3,6 +3,7 @@ package com.zerobase.hoops.gameUsers.repository;
 import com.zerobase.hoops.entity.GameEntity;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -16,4 +17,6 @@ public interface GameUserRepository extends
   List<GameEntity> findByAddressContainingIgnoreCaseAndStartDateTimeAfterOrderByStartDateTimeAsc(
       String partOfAddress, LocalDateTime currentDateTime);
 
+  Optional<GameEntity> findByGameIdAndStartDateTimeBefore(Long gameId,
+      LocalDateTime dateTime);
 }

--- a/src/main/java/com/zerobase/hoops/gameUsers/repository/MannerPointRepository.java
+++ b/src/main/java/com/zerobase/hoops/gameUsers/repository/MannerPointRepository.java
@@ -1,0 +1,11 @@
+package com.zerobase.hoops.gameUsers.repository;
+
+import com.zerobase.hoops.entity.MannerPointEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MannerPointRepository extends
+    JpaRepository<MannerPointEntity, Long> {
+
+}

--- a/src/main/java/com/zerobase/hoops/gameUsers/service/GameUserService.java
+++ b/src/main/java/com/zerobase/hoops/gameUsers/service/GameUserService.java
@@ -60,20 +60,20 @@ public class GameUserService {
         .orElseThrow(() -> new CustomException(
             ErrorCode.USER_NOT_FOUND));
 
-    Long GameLongId = Long.valueOf(gameId);
+    Long gameLongId = Long.valueOf(gameId);
 
     gameUserRepository.findByGameIdAndStartDateTimeBefore(
-            GameLongId, LocalDateTime.now())
+            gameLongId, LocalDateTime.now())
         .orElseThrow(() -> new CustomException(ErrorCode.GAME_NOT_FOUND));
 
     boolean finalCheck = gameCheckOutRepository.existsByGameEntity_GameIdAndUserEntity_UserIdAndStatus(
-        GameLongId, userId, ParticipantGameStatus.ACCEPT);
+        gameLongId, userId, ParticipantGameStatus.ACCEPT);
 
     if (!finalCheck) {
       throw new CustomException(ErrorCode.GAME_NOT_FOUND);
     }
     return gameCheckOutRepository.findByStatusAndGameEntity_GameId(
-            ParticipantGameStatus.ACCEPT, GameLongId)
+            ParticipantGameStatus.ACCEPT, gameLongId)
         .orElseThrow(
             () -> new CustomException(ErrorCode.GAME_NOT_FOUND));
   }

--- a/src/main/java/com/zerobase/hoops/gameUsers/service/GameUserService.java
+++ b/src/main/java/com/zerobase/hoops/gameUsers/service/GameUserService.java
@@ -13,6 +13,7 @@ import com.zerobase.hoops.gameCreator.type.ParticipantGameStatus;
 import com.zerobase.hoops.gameUsers.dto.GameSearchResponse;
 import com.zerobase.hoops.gameUsers.dto.ParticipateGameDto;
 import com.zerobase.hoops.gameUsers.repository.GameCheckOutRepository;
+import com.zerobase.hoops.gameUsers.repository.GameCheckOutSpecifications;
 import com.zerobase.hoops.gameUsers.repository.GameUserRepository;
 import com.zerobase.hoops.security.JwtTokenExtract;
 import com.zerobase.hoops.users.repository.UserRepository;
@@ -171,21 +172,21 @@ public class GameUserService {
       LocalDate localDate, CityName cityName, FieldStatus fieldStatus,
       Gender gender, MatchFormat matchFormat) {
     Specification<GameEntity> spec = Specification.where(
-        GameSpecifications.notDeleted());
+        GameCheckOutSpecifications.notDeleted());
     
-    spec = spec.and(GameSpecifications.startDate(localDate));
+    spec = spec.and(GameCheckOutSpecifications.startDate(localDate));
 
     if (cityName != null) {
-      spec = spec.and(GameSpecifications.withCityName(cityName));
+      spec = spec.and(GameCheckOutSpecifications.withCityName(cityName));
     }
     if (fieldStatus != null) {
-      spec = spec.and(GameSpecifications.withFieldStatus(fieldStatus));
+      spec = spec.and(GameCheckOutSpecifications.withFieldStatus(fieldStatus));
     }
     if (gender != null) {
-      spec = spec.and(GameSpecifications.withGender(gender));
+      spec = spec.and(GameCheckOutSpecifications.withGender(gender));
     }
     if (matchFormat != null) {
-      spec = spec.and(GameSpecifications.withMatchFormat(matchFormat));
+      spec = spec.and(GameCheckOutSpecifications.withMatchFormat(matchFormat));
     }
     return spec;
   }

--- a/src/main/java/com/zerobase/hoops/gameUsers/service/GameUserService.java
+++ b/src/main/java/com/zerobase/hoops/gameUsers/service/GameUserService.java
@@ -23,7 +23,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -32,7 +31,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.validation.BindingResult;
 
 @Slf4j
 @Service


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
참여헀던 경기의 유저 목록을 불러오는 기능 개발

**TO-BE**
- 조회하는 시점을 기준으로 이미 지난 경기를 불러옴
- 지난 경기중 실제로 ACCEPT 된 상태를 필터링

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [o] 테스트 코드
- [o] API 테스트 