### PR TITLE
fix : 토큰 갱신 로직 수정

### DIFF
--- a/src/main/java/com/zerobase/hoops/chat/service/ChatService.java
+++ b/src/main/java/com/zerobase/hoops/chat/service/ChatService.java
@@ -1,6 +1,5 @@
 package com.zerobase.hoops.chat.service;
 
-
 import com.zerobase.hoops.chat.domain.dto.ChatRoomDTO;
 import com.zerobase.hoops.chat.domain.dto.Content;
 import com.zerobase.hoops.chat.domain.dto.MessageDTO;
@@ -63,7 +62,7 @@ public class ChatService {
   }
 
   public UserEntity findUser(String senderId) {
-    return userRepository.findById(senderId)
+    return userRepository.findByIdAndDeletedDateTimeNull(senderId)
         .orElseThrow(()-> new CustomException(ErrorCode.USER_NOT_FOUND));
   }
 

--- a/src/main/java/com/zerobase/hoops/config/ChatPreHandler.java
+++ b/src/main/java/com/zerobase/hoops/config/ChatPreHandler.java
@@ -1,6 +1,5 @@
 package com.zerobase.hoops.config;
 
-
 import com.zerobase.hoops.exception.CustomException;
 import com.zerobase.hoops.security.TokenProvider;
 import io.jsonwebtoken.Claims;
@@ -122,7 +121,7 @@ public class ChatPreHandler implements ChannelInterceptor {
 
       try {
         Claims claims = tokenProvider.parseClaims(accessToken);
-        return claims.get("id", String.class);
+        return claims.get("sub", String.class);
       } catch (ExpiredJwtException | MalformedJwtException e) {
         throw new CustomException(EXPIRED_TOKEN);
       }

--- a/src/main/java/com/zerobase/hoops/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/hoops/exception/ErrorCode.java
@@ -13,13 +13,14 @@ public enum ErrorCode {
   PAST_BIRTHDAY(HttpStatus.BAD_REQUEST.value(), "생년월일은 과거의 날짜만 입력 가능합니다."),
 
   MAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR.value(), "메일 발송에 실패하였습니다."),
-  WRONG_EMAIL(HttpStatus.NO_CONTENT.value(), "잘못된 이메일 주소입니다."),
-  INVALID_NUMBER(HttpStatus.FORBIDDEN.value(), "유효하지 않은 인증번호입니다."),
+  WRONG_EMAIL(HttpStatus.NO_CONTENT.value(), "해당 이메일로 발송된 인증번호가 없습니다."),
+  NOT_MATCHED_NUMBER(HttpStatus.FORBIDDEN.value(), "인증번호가 일치하지 않습니다."),
   USER_NOT_CONFIRM(HttpStatus.BAD_REQUEST.value(), "인증되지 않은 회원입니다."),
 
   NOT_FOUND_TOKEN(HttpStatus.UNAUTHORIZED.value(), "토큰 형식의 값을 찾을 수 없습니다."),
   INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "유효하지 않은 토큰입니다."),
   EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "기간이 만료된 토큰입니다."),
+  EXPIRED_REFRESH_TOKEN(HttpStatus.FORBIDDEN.value(), "리프레시 토큰의 기간이 만료되었습니다."),
   NOT_MATCHED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "토큰 정보가 일치하지 않습니다."),
   UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "지원하지 않는 토큰입니다."),
   ACCESS_DENIED(HttpStatus.UNAUTHORIZED.value(), "알 수 없는 이유로 요청이 거절되었습니다."),

--- a/src/main/java/com/zerobase/hoops/security/JwtExceptionFilter.java
+++ b/src/main/java/com/zerobase/hoops/security/JwtExceptionFilter.java
@@ -39,6 +39,8 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         setResponse(response, ErrorCode.BAN_FOR_10DAYS);
       } else if (ErrorCode.ALREADY_LOGOUT.getDescription().equals(message)) {
         setResponse(response, ErrorCode.ALREADY_LOGOUT);
+      } else if (ErrorCode.EXPIRED_REFRESH_TOKEN.getDescription().equals(message)) {
+        setResponse(response, ErrorCode.EXPIRED_REFRESH_TOKEN);
       } else {
         setResponse(response, ErrorCode.ACCESS_DENIED);
       }

--- a/src/main/java/com/zerobase/hoops/security/TokenProvider.java
+++ b/src/main/java/com/zerobase/hoops/security/TokenProvider.java
@@ -50,29 +50,40 @@ public class TokenProvider {
    * AccessToken 생성
    */
   public String createAccessToken(String id, String email, List<String> role) {
-    return generateToken(id, email, role, ACCESS_TOKEN_EXPIRE_TIME);
+    return generateAccessToken(id, email, role, ACCESS_TOKEN_EXPIRE_TIME);
   }
 
   /**
    * RefreshToken 생성
    */
-  public String createRefreshToken(String id, String email, List<String> role) {
+  public String createRefreshToken(String id) {
 
     String refreshToken =
-        generateToken(id, email, role, REFRESH_TOKEN_EXPIRE_TIME);
+        generateRefreshToken(id, REFRESH_TOKEN_EXPIRE_TIME);
 
     authRepository.saveRefreshToken(
         id, refreshToken, Duration.ofMillis(REFRESH_TOKEN_EXPIRE_TIME));
     return refreshToken;
   }
 
-  public String generateToken(String id, String email, List<String> roles,
-      Long expireTime) {
+  public String generateAccessToken(String id, String email,
+      List<String> roles, Long expireTime) {
 
-    Claims claims = Jwts.claims().setSubject(email);
-    claims.put("id", id);
+    Claims claims = Jwts.claims().setSubject(id);
+    claims.put("email", email);
     claims.put("roles", roles);
 
+    return returnToken(claims, expireTime);
+  }
+
+  public String generateRefreshToken(String id, Long expireTime) {
+
+    Claims claims = Jwts.claims().setSubject(id);
+
+    return returnToken(claims, expireTime);
+  }
+
+  private String returnToken(Claims claims, Long expireTime) {
     var now = new Date();
     var expireDate = new Date(now.getTime() + expireTime);
 
@@ -107,6 +118,7 @@ public class TokenProvider {
 
   public boolean validateToken(String token) {
     try {
+      validateRefreshToken(token);
       Jws<Claims> claims = Jwts.parserBuilder()
           .setSigningKey(
               getSigningKey(secretKey.getBytes(StandardCharsets.UTF_8)))
@@ -129,10 +141,17 @@ public class TokenProvider {
       throw new JwtException(ErrorCode.INVALID_TOKEN.getDescription());
     } catch (CustomException e) {
       if(e.getErrorCode().equals(ErrorCode.ALREADY_LOGOUT)){
+        log.info("CustomException!!");
         throw new JwtException(ErrorCode.ALREADY_LOGOUT.getDescription());
-      } else {
+      } else if (e.getErrorCode().equals(ErrorCode.BAN_FOR_10DAYS)) {
         log.info("CustomException!!");
         throw new JwtException(ErrorCode.BAN_FOR_10DAYS.getDescription());
+      } else if (e.getErrorCode().equals(ErrorCode.EXPIRED_REFRESH_TOKEN)) {
+        log.info("CustomException!!");
+        throw new JwtException(ErrorCode.EXPIRED_REFRESH_TOKEN.getDescription());
+      } else {
+        log.info("CustomException!!");
+        throw new JwtException(ErrorCode.ACCESS_DENIED.getDescription());
       }
     }
   }
@@ -154,6 +173,12 @@ public class TokenProvider {
   public void checkLogOut(String token) {
     if (isLogOut(token)) {
       throw new CustomException(ErrorCode.ALREADY_LOGOUT);
+    }
+  }
+
+  public void validateRefreshToken(String token) {
+    if (token.length() == 152) {
+      throw new CustomException(ErrorCode.EXPIRED_REFRESH_TOKEN);
     }
   }
 

--- a/src/main/java/com/zerobase/hoops/users/repository/UserRepository.java
+++ b/src/main/java/com/zerobase/hoops/users/repository/UserRepository.java
@@ -14,10 +14,6 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
   boolean existsByNickNameAndDeletedDateTimeNull(String nickName);
 
-  Optional<UserEntity> findById(String id);
-
-  Optional<UserEntity> findByEmail(String email);
-
   Optional<UserEntity> findByEmailAndDeletedDateTimeNull(String email);
 
   Optional<UserEntity> findByIdAndDeletedDateTimeNull(String id);

--- a/src/main/java/com/zerobase/hoops/users/service/UserService.java
+++ b/src/main/java/com/zerobase/hoops/users/service/UserService.java
@@ -108,7 +108,7 @@ public class UserService implements UserDetailsService {
   public void confirmEmail(
       String id, String email, String certificationNumber) {
     if (!checkCertificationNumber(email, certificationNumber)) {
-      throw new CustomException(ErrorCode.INVALID_NUMBER);
+      throw new CustomException(ErrorCode.NOT_MATCHED_NUMBER);
     }
 
     UserEntity user = userRepository.findByIdAndDeletedDateTimeNull(id)
@@ -131,23 +131,23 @@ public class UserService implements UserDetailsService {
         .equals(certificationNumber);
   }
 
-  public UserDto getUserInfo(String userId) {
-    UserEntity userEntity = userRepository.findById(userId)
+  public UserDto getUserInfo(String id) {
+    UserEntity userEntity = userRepository.findByIdAndDeletedDateTimeNull(id)
         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     return UserDto.fromEntity(userEntity);
   }
 
   @Override
-  public UserDetails loadUserByUsername(String email)
+  public UserDetails loadUserByUsername(String id)
       throws UsernameNotFoundException {
-    return userRepository.findByEmailAndDeletedDateTimeNull(email)
+    return userRepository.findByIdAndDeletedDateTimeNull(id)
         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
   }
 
 
   public String findId(String email) {
     UserEntity user =
-        userRepository.findByEmail(email)
+        userRepository.findByEmailAndDeletedDateTimeNull(email)
             .orElseThrow(
                 () -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
@@ -156,7 +156,7 @@ public class UserService implements UserDetailsService {
 
   public boolean findPassword(String id) throws NoSuchAlgorithmException {
     UserEntity user =
-        userRepository.findById(id)
+        userRepository.findByIdAndDeletedDateTimeNull(id)
             .orElseThrow(
                 () -> new CustomException(ErrorCode.USER_NOT_FOUND));
 


### PR DESCRIPTION
### 변경사항
**AS-IS**
 - id 로 UserEntity 조회 시 조건이 없음 -> 탈퇴 회원도 조회
 - 토큰 갱신 시 만료된 access token, refresh token 함께 요청 -> 토큰 필터에서 만료된 토큰이라고 예외 발생
 - access token 과 refresh token 의 생성 조건이 시간 빼고 전부 같음

**TO-BE**
 - 토큰 갱신 로직 수정
	 - refresh token 을 Authorization 에 담아 요청
 - ErrorCode 설명 직관적으로 수정 및 refresh token 만료 코드 추가
 - refresh token 으로 요청 후 예외 발생 시 토큰 필터에서 핸들링
 - access token, refresh token 생성 데이터 분리
	 - access token : id (subject), email, roles
	 - refresh token : id (subject)
	 - 이에 따른 claims 에서 아이디 추출 시 get("id") -> get("sub") 로 수정
 - 탈퇴 회원은 조회하지 않도록 조건 추가

### 테스트
- [x] 테스트 코드
- [x] API 테스트 