### PR TITLE
[feat] 알림 타입 컬럼 추가

### DIFF
--- a/src/main/java/com/zerobase/hoops/alarm/controller/NotificationController.java
+++ b/src/main/java/com/zerobase/hoops/alarm/controller/NotificationController.java
@@ -11,11 +11,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class NotificationController {
 
   private final NotificationService notificationService;

--- a/src/main/java/com/zerobase/hoops/alarm/domain/NotificationDto.java
+++ b/src/main/java/com/zerobase/hoops/alarm/domain/NotificationDto.java
@@ -2,13 +2,15 @@ package com.zerobase.hoops.alarm.domain;
 
 import com.zerobase.hoops.entity.NotificationEntity;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-
+@AllArgsConstructor
+@Builder
 public class NotificationDto {
 
   // 알림 id (Pk)
@@ -17,19 +19,15 @@ public class NotificationDto {
   // 알림 내용
   private String content;
 
+  private String type;
   private LocalDateTime createdDateTime;
 
-  @Builder
-  public NotificationDto(Long id, String content, LocalDateTime createdDateTime) {
-    this.id = id;
-    this.content = content;
-    this.createdDateTime = createdDateTime;
-  }
 
   public static NotificationDto entityToDto(
       NotificationEntity notificationEntity) {
     return NotificationDto.builder()
         .id(notificationEntity.getId())
+        .type(notificationEntity.getNotificationType().toString())
         .content(notificationEntity.getContent())
         .createdDateTime(notificationEntity.getCreatedDateTime())
         .build();

--- a/src/main/java/com/zerobase/hoops/alarm/domain/NotificationType.java
+++ b/src/main/java/com/zerobase/hoops/alarm/domain/NotificationType.java
@@ -1,0 +1,5 @@
+package com.zerobase.hoops.alarm.domain;
+
+public enum NotificationType {
+  KICKED_OUT, ACCEPTED_GAME, REJECTED_GAME, REPORT, FRIEND
+}

--- a/src/main/java/com/zerobase/hoops/alarm/service/NotificationService.java
+++ b/src/main/java/com/zerobase/hoops/alarm/service/NotificationService.java
@@ -1,6 +1,7 @@
 package com.zerobase.hoops.alarm.service;
 
 
+import com.zerobase.hoops.alarm.domain.NotificationType;
 import com.zerobase.hoops.entity.NotificationEntity;
 import com.zerobase.hoops.alarm.domain.NotificationDto;
 import com.zerobase.hoops.alarm.repository.EmitterRepository;
@@ -86,8 +87,9 @@ public class NotificationService {
   }
 
   @Transactional
-  public void send(UserEntity receiver, String content) {
-    NotificationEntity notificationEntity = createNotification(receiver, content);
+  public void send(NotificationType type, UserEntity receiver, String content) {
+    NotificationEntity notificationEntity = createNotification(
+        type, receiver, content);
     notificationRepository.save(notificationEntity);
     Map<String, SseEmitter> sseEmitters =
         emitterRepository.findAllStartWithByUserId(
@@ -102,9 +104,11 @@ public class NotificationService {
     );
   }
 
-  private NotificationEntity createNotification(UserEntity receiver, String content) {
+  private NotificationEntity createNotification(NotificationType type,
+      UserEntity receiver, String content) {
     return NotificationEntity.builder()
         .receiver(receiver)
+        .notificationType(type)
         .content(content)
         .createdDateTime(LocalDateTime.now())
         .build();

--- a/src/main/java/com/zerobase/hoops/entity/NotificationEntity.java
+++ b/src/main/java/com/zerobase/hoops/entity/NotificationEntity.java
@@ -1,8 +1,11 @@
 package com.zerobase.hoops.entity;
 
+import com.zerobase.hoops.alarm.domain.NotificationType;
 import com.zerobase.hoops.entity.UserEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -31,6 +34,8 @@ public class NotificationEntity {
   @JoinColumn(nullable = false)
   private UserEntity receiver;
 
+  @Enumerated(EnumType.STRING)
+  private NotificationType notificationType;
   private String content;
   private LocalDateTime createdDateTime;
 

--- a/src/main/java/com/zerobase/hoops/friends/service/FriendService.java
+++ b/src/main/java/com/zerobase/hoops/friends/service/FriendService.java
@@ -12,6 +12,7 @@ import static com.zerobase.hoops.exception.ErrorCode.OTHER_FRIEND_FULL;
 import static com.zerobase.hoops.exception.ErrorCode.SELF_FRIEND_FULL;
 import static com.zerobase.hoops.exception.ErrorCode.USER_NOT_FOUND;
 
+import com.zerobase.hoops.alarm.domain.NotificationType;
 import com.zerobase.hoops.alarm.service.NotificationService;
 import com.zerobase.hoops.entity.FriendEntity;
 import com.zerobase.hoops.entity.UserEntity;
@@ -103,7 +104,8 @@ public class FriendService {
         .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
     FriendEntity friendEntity = ApplyRequest.toEntity(user, friendUserEntity);
-    notificationService.send(friendUserEntity, "친구신청이 도착했습니다.");
+    notificationService.send(NotificationType.FRIEND,
+        friendUserEntity, "친구신청이 도착했습니다.");
     friendRepository.save(friendEntity);
 
     return ApplyResponse.toDto(friendEntity);

--- a/src/main/java/com/zerobase/hoops/gameCreator/service/ParticipantGameService.java
+++ b/src/main/java/com/zerobase/hoops/gameCreator/service/ParticipantGameService.java
@@ -10,6 +10,7 @@ import static com.zerobase.hoops.exception.ErrorCode.USER_NOT_FOUND;
 import static com.zerobase.hoops.gameCreator.type.ParticipantGameStatus.ACCEPT;
 import static com.zerobase.hoops.gameCreator.type.ParticipantGameStatus.APPLY;
 
+import com.zerobase.hoops.alarm.domain.NotificationType;
 import com.zerobase.hoops.alarm.service.NotificationService;
 import com.zerobase.hoops.entity.GameEntity;
 import com.zerobase.hoops.entity.ParticipantGameEntity;
@@ -126,7 +127,8 @@ public class ParticipantGameService {
     ParticipantGameEntity result =
         ParticipantGameEntity.setAccept(participantGameEntity);
 
-    notificationService.send(result.getUserEntity(), "경기참가에 수락되었습니다.");
+    notificationService.send(NotificationType.ACCEPTED_GAME,
+        result.getUserEntity(), "경기참가에 수락되었습니다.");
     participantGameRepository.save(result);
 
     log.info("acceptParticipant end");
@@ -150,7 +152,8 @@ public class ParticipantGameService {
     ParticipantGameEntity result =
         ParticipantGameEntity.setReject(participantGameEntity);
 
-    notificationService.send(result.getUserEntity(), "경기참가에 거절되었습니다.");
+    notificationService.send(NotificationType.REJECTED_GAME,
+        result.getUserEntity(), "경기참가에 거절되었습니다.");
     participantGameRepository.save(result);
 
     log.info("rejectParticipant end");
@@ -183,12 +186,12 @@ public class ParticipantGameService {
         ParticipantGameEntity.setKickout(participantGameEntity);
 
     participantGameRepository.save(result);
-    notificationService.send(result.getUserEntity(), "경기에서 강퇴당하였습니다.");
+    notificationService.send(NotificationType.KICKED_OUT,
+        result.getUserEntity(), "경기에서 강퇴당하였습니다.");
 
     log.info("kickoutParticipant end");
     return KickoutResponse.toDto(result);
   }
-
 
 
   public void setUpUser() {

--- a/src/main/java/com/zerobase/hoops/reports/service/ReportService.java
+++ b/src/main/java/com/zerobase/hoops/reports/service/ReportService.java
@@ -1,5 +1,6 @@
 package com.zerobase.hoops.reports.service;
 
+import com.zerobase.hoops.alarm.domain.NotificationType;
 import com.zerobase.hoops.alarm.service.NotificationService;
 import com.zerobase.hoops.entity.ReportEntity;
 import com.zerobase.hoops.entity.UserEntity;
@@ -59,7 +60,8 @@ public class ReportService {
 
     checkExist(request, user);
 
-    notificationService.send(findManger(), "신고가 접수되었습니다.");
+    notificationService.send(NotificationType.REPORT, findManger(),
+        "신고가 접수되었습니다.");
 
     reportRepository.save(request.toEntity(user, reportedUser));
   }

--- a/src/test/java/com/zerobase/hoops/alarm/controller/NotificationControllerTest.java
+++ b/src/test/java/com/zerobase/hoops/alarm/controller/NotificationControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zerobase.hoops.alarm.domain.NotificationDto;
+import com.zerobase.hoops.alarm.domain.NotificationType;
 import com.zerobase.hoops.alarm.service.NotificationService;
 import com.zerobase.hoops.entity.UserEntity;
 import com.zerobase.hoops.manager.service.ManagerService;
@@ -100,11 +101,14 @@ class NotificationControllerTest {
     // given
     List<NotificationDto> notificationDtos = new ArrayList<>();
     notificationDtos.add(
-        new NotificationDto(1L, "첫번째알림", LocalDateTime.now().plusDays(1)));
+        new NotificationDto(1L, "FRIEND",
+            "첫번째알림", LocalDateTime.now().plusDays(1)));
     notificationDtos.add(
-        new NotificationDto(2L, "두번째알림", LocalDateTime.now().plusDays(2)));
+        new NotificationDto(2L,"REPORT",
+            "두번째알림", LocalDateTime.now().plusDays(2)));
     notificationDtos.add(
-        new NotificationDto(3L, "세번째알림", LocalDateTime.now().plusDays(3)));
+        new NotificationDto(3L, "REJECTED_GAME",
+            "세번째알림", LocalDateTime.now().plusDays(3)));
 
     // when
     when(notificationService.findAllById(any())).thenReturn(notificationDtos);


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 알림을 구분할 수 있는 별도의 컬럼이 존재하지 않았음

**TO-BE**
- 친구추가, 신고접수, 경기 참여 수락, 경기 참여 거절, 강퇴 알림 구분 가능한 컬럼 추가