### PR TITLE
refactor : 카카오 로그인/로그아웃 수정

### DIFF
--- a/src/main/java/com/zerobase/hoops/users/controller/AuthController.java
+++ b/src/main/java/com/zerobase/hoops/users/controller/AuthController.java
@@ -88,6 +88,9 @@ public class AuthController {
       HttpServletRequest request,
       @AuthenticationPrincipal UserEntity userEntity
   ) {
+    if (userEntity.getId().startsWith("kakao_")) {
+      oAuth2Service.kakaoLogout(request, userEntity);
+    }
     authService.logOutUser(request, userEntity);
 
     return ResponseEntity.ok(HttpStatus.OK);

--- a/src/main/java/com/zerobase/hoops/users/oauth2/controller/OAuth2KakaoController.java
+++ b/src/main/java/com/zerobase/hoops/users/oauth2/controller/OAuth2KakaoController.java
@@ -6,9 +6,6 @@ import com.zerobase.hoops.users.dto.TokenDto;
 import com.zerobase.hoops.users.dto.UserDto;
 import com.zerobase.hoops.users.oauth2.service.OAuth2Service;
 import com.zerobase.hoops.users.service.AuthService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
@@ -16,34 +13,22 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/oauth2")
-@Tag(name = "5. OAUTH2")
-public class OAuth2Controller {
+public class OAuth2KakaoController {
 
   private final OAuth2Service oAuth2Service;
   private final AuthService authService;
 
-  /**
-   * 카카오 로그인
-   */
-  @Operation(summary = "카카오 로그인")
-  @GetMapping("/login/kakao")
-  public void getKakaoAuthUrl(HttpServletResponse response) throws IOException {
-    response.sendRedirect(oAuth2Service.responseUrl());
-  }
-
-  @GetMapping("/kakao")
+  @GetMapping("https://hoops-frontend-jet.vercel.app")
   public ResponseEntity<Response> kakaoLogin(
       @RequestParam(name = "code") String code, HttpSession session)
       throws IOException {
-    log.info("카카오 API 서버 code : " + code);
+    log.info("새로운 컨트롤러 카카오 API 서버 code : " + code);
     UserDto userDto = oAuth2Service.kakaoLogin(code, session);
     TokenDto tokenDto = authService.getToken(userDto);
 

--- a/src/main/java/com/zerobase/hoops/users/oauth2/service/OAuth2Service.java
+++ b/src/main/java/com/zerobase/hoops/users/oauth2/service/OAuth2Service.java
@@ -46,7 +46,7 @@ public class OAuth2Service {
 
   public String responseUrl() {
     return authorizationUri + "?client_id=" + clientId +
-        "&redirect_uri=https://hoops.services/api/oauth2/kakao"
+        "&redirect_uri=https://hoops-frontend-jet.vercel.app"
         + "&response_type=code";
   }
 
@@ -129,7 +129,7 @@ public class OAuth2Service {
     params.add("grant_type", "authorization_code");
     params.add("client_id", clientId);
     params.add("client_secret", clientSecret);
-    params.add("redirect_uri", "https://hoops.services/api/oauth2/kakao");
+    params.add("redirect_uri", "https://hoops-frontend-jet.vercel.app");
     params.add("code", code);
 
     HttpEntity<MultiValueMap<String, String>> kakaoRequest =


### PR DESCRIPTION
### 변경사항
**AS-IS**
 - 카카오 로그인 redirect uri 백앤드 도메인으로 설정
 - 카카오 로그아웃 따로 작성

**TO-BE**
 - redirect uri 프론트 홈 화면으로 설정
 - 기본 로그아웃 로직에 조건 추가 : 아이디가 'kakao_' 로 시작하면 카카오 로그아웃 추가 실행

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 