### PR TITLE
fix : 카카오 로그인 전체 동의 시 DB에 저장 안되는 에러 수정

### DIFF
--- a/src/main/java/com/zerobase/hoops/users/oauth2/service/OAuth2Service.java
+++ b/src/main/java/com/zerobase/hoops/users/oauth2/service/OAuth2Service.java
@@ -66,9 +66,6 @@ public class OAuth2Service {
           , "MALE");
 
       userRepository.save(KakaoDto.Request.toEntity(user));
-
-      LogInDto.Request logInDto = kakaoUserLogin(id);
-      return authService.logInUser(logInDto);
     } else if (kakaoAccount.getEmail() == null && kakaoAccount.getGender() != null
         && !userRepository.existsByEmailAndDeletedDateTimeNull(id + "@kakao.com")) {
       KakaoDto.Request user = kakaoUserDto(
@@ -78,9 +75,6 @@ public class OAuth2Service {
           , kakaoAccount.getGender());
 
       userRepository.save(KakaoDto.Request.toEntity(user));
-
-      LogInDto.Request logInDto = kakaoUserLogin(id);
-      return authService.logInUser(logInDto);
     } else if (kakaoAccount.getEmail() != null && kakaoAccount.getGender() == null
         && !userRepository.existsByEmailAndDeletedDateTimeNull(kakaoAccount.getEmail())) {
       KakaoDto.Request user = kakaoUserDto(
@@ -90,9 +84,14 @@ public class OAuth2Service {
           , "MALE");
 
       userRepository.save(KakaoDto.Request.toEntity(user));
+    } else {
+      KakaoDto.Request user = kakaoUserDto(
+          id,
+          kakaoAccount.getEmail(),
+          properties.getNickname()
+          , kakaoAccount.getGender());
 
-      LogInDto.Request logInDto = kakaoUserLogin(id);
-      return authService.logInUser(logInDto);
+      userRepository.save(KakaoDto.Request.toEntity(user));
     }
     LogInDto.Request logInDto = kakaoUserLogin(id);
     return authService.logInUser(logInDto);


### PR DESCRIPTION
### 변경사항
**AS-IS**
 - 카카오 로그인 전체 동의 시 DB 저장 안됨

**TO-BE**
 - 로직 수정 -> 에러 해결

### 테스트
- [ ] 테스트 코드
- [x] API 테스트 