### PR TITLE
refactor : 이메일 발송 비동기 방식으로 전환

### DIFF
--- a/src/main/java/com/zerobase/hoops/config/AsyncConfig.java
+++ b/src/main/java/com/zerobase/hoops/config/AsyncConfig.java
@@ -1,0 +1,22 @@
+package com.zerobase.hoops.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+  @Bean
+  public Executor taskExecutor() {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(2);
+    executor.setMaxPoolSize(5);
+    executor.setQueueCapacity(500);
+    executor.setThreadNamePrefix("EmailThread-");
+    executor.initialize();
+    return executor;
+  }
+}

--- a/src/main/java/com/zerobase/hoops/users/provider/EmailProvider.java
+++ b/src/main/java/com/zerobase/hoops/users/provider/EmailProvider.java
@@ -4,6 +4,7 @@ import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,7 +15,8 @@ public class EmailProvider {
   private final String SUBJECT = "[HOOPS] 인증 메일입니다.";
   private final String PASSWORD_SUBJECT = "[HOOPS] 임시 비밀번호입니다.";
 
-  public boolean sendCertificationMail(String loginId, String email,
+  @Async
+  public void sendCertificationMail(String loginId, String email,
       String certificationNumber) {
     try {
       MimeMessage message = javaMailSender.createMimeMessage();
@@ -31,10 +33,7 @@ public class EmailProvider {
       javaMailSender.send(message);
     } catch (Exception e) {
       e.printStackTrace();
-      return false;
     }
-
-    return true;
   }
 
   private String getCertificationMessage(String loginId, String email,
@@ -47,7 +46,7 @@ public class EmailProvider {
     certificationMessage +=
         "<h3 style='text-align: center;'>"
             + "인증 링크 : "
-            + "<a href=\"https://hoops.services/api/user/signup/confirm?loginId=" + loginId
+            + "<a href=\"http://localhost:8080/api/user/signup/confirm?loginId=" + loginId
             + "&email=" + email + "&certificationNumber=" + certificationNumber
             + "\">"
             + "이곳을 눌러 인증을 완료해주세요. 링크는 3분 동안 유효합니다."
@@ -57,7 +56,8 @@ public class EmailProvider {
     return certificationMessage;
   }
 
-  public boolean sendTemporaryPasswordMail(String email, String newPassword) {
+  @Async
+  public void sendTemporaryPasswordMail(String email, String newPassword) {
     try {
       MimeMessage message = javaMailSender.createMimeMessage();
       MimeMessageHelper messageHelper =
@@ -72,10 +72,7 @@ public class EmailProvider {
       javaMailSender.send(message);
     } catch (Exception e) {
       e.printStackTrace();
-      return false;
     }
-
-    return true;
   }
 
   private String getTemporaryPasswordMessage(String newPassword) {

--- a/src/main/java/com/zerobase/hoops/users/service/UserService.java
+++ b/src/main/java/com/zerobase/hoops/users/service/UserService.java
@@ -59,11 +59,11 @@ public class UserService implements UserDetailsService {
 
       String certificationNumber =
           CertificationProvider.createCertificationNumber();
-      boolean isSuccess =
-          emailProvider.sendCertificationMail(loginId, email,
-              certificationNumber);
-      if (!isSuccess) {
-        throw new CustomException(ErrorCode.MAIL_SEND_FAIL);
+      try {
+        emailProvider.sendCertificationMail(loginId, email,
+            certificationNumber);
+      } catch (Exception e) {
+        e.printStackTrace();
       }
       emailRepository.saveCertificationNumber(email, certificationNumber);
 
@@ -168,12 +168,13 @@ public class UserService implements UserDetailsService {
 
     String email = user.getEmail();
 
-    boolean isSuccess =
-        emailProvider.sendTemporaryPasswordMail(email, newPassword);
-    if (!isSuccess) {
-      throw new CustomException(ErrorCode.MAIL_SEND_FAIL);
+    try {
+      emailProvider.sendTemporaryPasswordMail(email, newPassword);
+    } catch (Exception e) {
+      e.printStackTrace();
+      return false;
     }
 
-    return isSuccess;
+    return true;
   }
 }

--- a/src/test/java/com/zerobase/hoops/users/service/UserServiceTest.java
+++ b/src/test/java/com/zerobase/hoops/users/service/UserServiceTest.java
@@ -3,6 +3,7 @@ package com.zerobase.hoops.users.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 import com.zerobase.hoops.entity.UserEntity;
@@ -92,8 +93,7 @@ class UserServiceTest {
 
     UserEntity user = SignUpDto.Request.toEntity(request);
 
-    when(emailProvider.sendCertificationMail(
-        any(), any(), any())).thenReturn(true);
+    doNothing().when(emailProvider).sendCertificationMail(any(), any(), any());
 
     when(userRepository.save(any(UserEntity.class))).thenReturn(user);
 
@@ -224,31 +224,6 @@ class UserServiceTest {
 
     // then
     assertEquals("이미 사용 중인 별명입니다.", exception.getMessage());
-  }
-
-  @Test
-  @DisplayName("User_SignUp_Fail_EmailSendFail")
-  void signUpUserTest_EmailSendFail() {
-    // given
-    SignUpDto.Request request = SignUpDto.Request.builder()
-        .loginId("signUpTest")
-        .password("Hoops!@#456")
-        .passwordCheck("Hoops!@#456")
-        .email("sign@hoops.com")
-        .name("성공")
-        .birthday(LocalDate.parse("19900101",
-            DateTimeFormatter.ofPattern("yyyyMMdd")))
-        .gender("MALE")
-        .nickName("별명")
-        .playStyle("BALANCE")
-        .ability("DRIBBLE")
-        .build();
-
-    when(emailProvider.sendCertificationMail(any(), any(), any())).thenReturn(
-        false);
-
-    // then
-    assertThrows(CustomException.class, () -> userService.signUpUser(request));
   }
 
   @Test
@@ -461,8 +436,8 @@ class UserServiceTest {
     // when
     when(userRepository.findByLoginIdAndDeletedDateTimeNull(existingId)).thenReturn(
         Optional.of(existingUser));
-    when(emailProvider.sendTemporaryPasswordMail(anyString(),
-        anyString())).thenReturn(true);
+    doNothing().when(emailProvider).sendTemporaryPasswordMail(anyString(),
+        anyString());
 
     // then
     assertTrue(userService.findPassword(existingId));
@@ -482,26 +457,5 @@ class UserServiceTest {
 
     // then
     assertEquals("아이디가 존재하지 않습니다.", exception.getMessage());
-  }
-
-  @Test
-  @DisplayName("User_findPassword_Fail_EmailSendFail")
-  void findPasswordTest_EmailSendFail() {
-    // given
-    String existingId = "existingId";
-
-    UserEntity existingUser = UserEntity.builder().loginId(existingId)
-        .email("existingEmail@test.com").build();
-
-    // when
-    when(userRepository.findByLoginIdAndDeletedDateTimeNull(existingId)).thenReturn(
-        Optional.of(existingUser));
-    when(emailProvider.sendTemporaryPasswordMail(any(), any())).thenReturn(
-        false);
-    Throwable exception = assertThrows(CustomException.class,
-        () -> userService.findPassword(existingId));
-
-    // then
-    assertEquals("메일 발송에 실패하였습니다.", exception.getMessage());
   }
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
 - 메일 발송 메서드 실행 시간에 따른 회원 가입, 비밀번호 찾기 호출 시간이 불필요하게 길어짐
 - 메일 발송 메서드 반환 값 boolean -> 반환 값에 따른 에러 throw

**TO-BE**
 - AsyncConfig 파일 작성 : @Async 어노테이션이 붙은 메서드의 처리 방식 설정
 - 메일 발송 비동기 방식으로 전환 -> 회원 가입, 비밀번호 찾기 호출 시간 단축
 - 메일 발송 메서드 void 방식으로 전환 후 try-catch 문으로 에러 catch
 - Test 코드에서 실패 케이스 삭제

### 테스트
- [x] 테스트 코드
- [x] API 테스트 