### PR TITLE
InviteServiceTest any() 삭제 및 실패 케이스 작성

### DIFF
--- a/src/main/java/com/zerobase/hoops/entity/InviteEntity.java
+++ b/src/main/java/com/zerobase/hoops/entity/InviteEntity.java
@@ -11,7 +11,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -63,36 +65,71 @@ public class InviteEntity {
   @JoinColumn(nullable = false)
   private GameEntity game;
 
-  public static InviteEntity toCancelEntity(InviteEntity inviteEntity) {
+  public void assignSenderUser(UserEntity user) {
+    this.senderUser = user;
+  }
+
+  public void assignReceiverUser(UserEntity user) {
+    this.receiverUser = user;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    InviteEntity that = (InviteEntity) o;
+    return Objects.equals(id, that.id) &&
+        Objects.equals(inviteStatus, that.inviteStatus) &&
+        Objects.equals(requestedDateTime, that.requestedDateTime) &&
+        Objects.equals(canceledDateTime, that.canceledDateTime) &&
+        Objects.equals(acceptedDateTime, that.acceptedDateTime) &&
+        Objects.equals(rejectedDateTime, that.rejectedDateTime) &&
+        Objects.equals(deletedDateTime, that.deletedDateTime) &&
+        Objects.equals(senderUser, that.senderUser) &&
+        Objects.equals(receiverUser, that.receiverUser) &&
+        Objects.equals(game, that.game);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, inviteStatus,
+        requestedDateTime, canceledDateTime, acceptedDateTime,
+        rejectedDateTime, deletedDateTime, senderUser, receiverUser, game);
+  }
+
+  public static InviteEntity toCancelEntity(InviteEntity inviteEntity,
+      Clock clock) {
     return InviteEntity.builder()
         .id(inviteEntity.getId())
         .inviteStatus(InviteStatus.CANCEL)
         .requestedDateTime(inviteEntity.getRequestedDateTime())
-        .canceledDateTime(LocalDateTime.now())
+        .canceledDateTime(LocalDateTime.now(clock))
         .senderUser(inviteEntity.getSenderUser())
         .receiverUser(inviteEntity.getReceiverUser())
         .game(inviteEntity.getGame())
         .build();
   }
 
-  public static InviteEntity toAcceptEntity(InviteEntity inviteEntity) {
+  public static InviteEntity toAcceptEntity(InviteEntity inviteEntity,
+      LocalDateTime nowDateTime) {
     return InviteEntity.builder()
         .id(inviteEntity.getId())
         .inviteStatus(InviteStatus.ACCEPT)
         .requestedDateTime(inviteEntity.getRequestedDateTime())
-        .acceptedDateTime(LocalDateTime.now())
+        .acceptedDateTime(nowDateTime)
         .senderUser(inviteEntity.getSenderUser())
         .receiverUser(inviteEntity.getReceiverUser())
         .game(inviteEntity.getGame())
         .build();
   }
 
-  public static InviteEntity toRejectEntity(InviteEntity inviteEntity) {
+  public static InviteEntity toRejectEntity(InviteEntity inviteEntity,
+      Clock clock) {
     return InviteEntity.builder()
         .id(inviteEntity.getId())
         .inviteStatus(InviteStatus.REJECT)
         .requestedDateTime(inviteEntity.getRequestedDateTime())
-        .rejectedDateTime(LocalDateTime.now())
+        .rejectedDateTime(LocalDateTime.now(clock))
         .senderUser(inviteEntity.getSenderUser())
         .receiverUser(inviteEntity.getReceiverUser())
         .game(inviteEntity.getGame())

--- a/src/main/java/com/zerobase/hoops/entity/ParticipantGameEntity.java
+++ b/src/main/java/com/zerobase/hoops/entity/ParticipantGameEntity.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
@@ -123,10 +124,8 @@ public class ParticipantGameEntity {
         .build();
   }
 
-  public static ParticipantGameEntity gameCreatorInvite(InviteEntity inviteEntity) {
-
-    LocalDateTime nowDateTime = LocalDateTime.now();
-
+  public static ParticipantGameEntity gameCreatorInvite(InviteEntity inviteEntity,
+      LocalDateTime nowDateTime) {
     return ParticipantGameEntity.builder()
             .status(ParticipantGameStatus.ACCEPT)
             .createdDateTime(nowDateTime)

--- a/src/main/java/com/zerobase/hoops/invite/dto/InviteDto.java
+++ b/src/main/java/com/zerobase/hoops/invite/dto/InviteDto.java
@@ -15,10 +15,12 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 public class InviteDto {
@@ -83,6 +85,7 @@ public class InviteDto {
   }
 
   @Getter
+  @Setter
   @ToString
   @NoArgsConstructor
   @AllArgsConstructor
@@ -228,80 +231,52 @@ public class InviteDto {
   public static class InviteMyListResponse {
     private Long inviteId;
 
-    private InviteStatus inviteStatus;
+    private LocalDate birthday;
 
-    private LocalDateTime requestedDateTime;
+    private GenderType gender;
 
-    private Long senderUserId;
+    private String nickName;
 
-    private LocalDate senderUserBirthday;
+    private PlayStyleType playStyle;
 
-    private GenderType senderUserGenderType;
-
-    private String senderUserNickName;
-
-    private PlayStyleType senderUserPlayStyle;
-
-    private AbilityType senderUserAbility;
+    private AbilityType ability;
 
     private String mannerPoint;
 
-    private String receiverUserNickName;
-
     private Long gameId;
 
-    private String title;
 
-    private String content;
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      InviteMyListResponse that = (InviteMyListResponse) o;
+      return Objects.equals(inviteId, that.inviteId) &&
+          Objects.equals(birthday, that.birthday) &&
+          Objects.equals(gender, that.gender) &&
+          Objects.equals(nickName, that.nickName) &&
+          Objects.equals(playStyle, that.playStyle) &&
+          Objects.equals(ability, that.ability) &&
+          Objects.equals(mannerPoint, that.mannerPoint) &&
+          Objects.equals(gameId, that.gameId);
+    }
 
-    private Long headCount;
-
-    private FieldStatus fieldStatus;
-
-    private Gender gender;
-
-    private LocalDateTime startDateTime;
-
-    private Boolean inviteYn;
-
-    private String address;
-
-    private Double latitude;
-
-    private Double longitude;
-
-    private CityName cityName;
-
-    private MatchFormat matchFormat;
-
-
+    @Override
+    public int hashCode() {
+      return Objects.hash(inviteId, birthday, gender, nickName,
+          playStyle, ability, mannerPoint, gameId);
+    }
 
     public static InviteMyListResponse toDto(InviteEntity inviteEntity) {
       return InviteMyListResponse.builder()
           .inviteId(inviteEntity.getId())
-          .inviteStatus(inviteEntity.getInviteStatus())
-          .requestedDateTime(inviteEntity.getRequestedDateTime())
-          .senderUserId(inviteEntity.getSenderUser().getId())
-          .senderUserBirthday(inviteEntity.getSenderUser().getBirthday())
-          .senderUserGenderType(inviteEntity.getSenderUser().getGender())
-          .senderUserNickName(inviteEntity.getSenderUser().getNickName())
-          .senderUserPlayStyle(inviteEntity.getSenderUser().getPlayStyle())
-          .senderUserAbility(inviteEntity.getSenderUser().getAbility())
+          .birthday(inviteEntity.getSenderUser().getBirthday())
+          .gender(inviteEntity.getSenderUser().getGender())
+          .nickName(inviteEntity.getSenderUser().getNickName())
+          .playStyle(inviteEntity.getSenderUser().getPlayStyle())
+          .ability(inviteEntity.getSenderUser().getAbility())
           .mannerPoint(inviteEntity.getSenderUser().getStringAverageRating())
-          .receiverUserNickName(inviteEntity.getReceiverUser().getNickName())
           .gameId(inviteEntity.getGame().getId())
-          .title(inviteEntity.getGame().getTitle())
-          .content(inviteEntity.getGame().getContent())
-          .headCount(inviteEntity.getGame().getHeadCount())
-          .fieldStatus(inviteEntity.getGame().getFieldStatus())
-          .gender(inviteEntity.getGame().getGender())
-          .startDateTime(inviteEntity.getGame().getStartDateTime())
-          .inviteYn(inviteEntity.getGame().getInviteYn())
-          .address(inviteEntity.getGame().getAddress())
-          .latitude(inviteEntity.getGame().getLatitude())
-          .longitude(inviteEntity.getGame().getLongitude())
-          .cityName(inviteEntity.getGame().getCityName())
-          .matchFormat(inviteEntity.getGame().getMatchFormat())
           .build();
     }
   }

--- a/src/test/java/com/zerobase/hoops/invite/service/InviteServiceTest.java
+++ b/src/test/java/com/zerobase/hoops/invite/service/InviteServiceTest.java
@@ -1,10 +1,10 @@
 package com.zerobase.hoops.invite.service;
 
 import static com.zerobase.hoops.gameCreator.type.ParticipantGameStatus.ACCEPT;
+import static com.zerobase.hoops.gameCreator.type.ParticipantGameStatus.APPLY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.zerobase.hoops.entity.FriendEntity;
@@ -12,6 +12,8 @@ import com.zerobase.hoops.entity.GameEntity;
 import com.zerobase.hoops.entity.InviteEntity;
 import com.zerobase.hoops.entity.ParticipantGameEntity;
 import com.zerobase.hoops.entity.UserEntity;
+import com.zerobase.hoops.exception.CustomException;
+import com.zerobase.hoops.exception.ErrorCode;
 import com.zerobase.hoops.friends.repository.FriendRepository;
 import com.zerobase.hoops.friends.type.FriendStatus;
 import com.zerobase.hoops.gameCreator.repository.GameRepository;
@@ -22,14 +24,10 @@ import com.zerobase.hoops.gameCreator.type.Gender;
 import com.zerobase.hoops.gameCreator.type.MatchFormat;
 import com.zerobase.hoops.gameCreator.type.ParticipantGameStatus;
 import com.zerobase.hoops.invite.dto.InviteDto.CancelRequest;
-import com.zerobase.hoops.invite.dto.InviteDto.CancelResponse;
 import com.zerobase.hoops.invite.dto.InviteDto.CreateRequest;
-import com.zerobase.hoops.invite.dto.InviteDto.CreateResponse;
 import com.zerobase.hoops.invite.dto.InviteDto.InviteMyListResponse;
 import com.zerobase.hoops.invite.dto.InviteDto.ReceiveAcceptRequest;
-import com.zerobase.hoops.invite.dto.InviteDto.ReceiveAcceptResponse;
 import com.zerobase.hoops.invite.dto.InviteDto.ReceiveRejectRequest;
-import com.zerobase.hoops.invite.dto.InviteDto.ReceiveRejectResponse;
 import com.zerobase.hoops.invite.repository.InviteRepository;
 import com.zerobase.hoops.invite.type.InviteStatus;
 import com.zerobase.hoops.security.JwtTokenExtract;
@@ -37,8 +35,11 @@ import com.zerobase.hoops.users.repository.UserRepository;
 import com.zerobase.hoops.users.type.AbilityType;
 import com.zerobase.hoops.users.type.GenderType;
 import com.zerobase.hoops.users.type.PlayStyleType;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -46,8 +47,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -74,14 +77,17 @@ class InviteServiceTest {
   @Mock
   private InviteRepository inviteRepository;
 
+  @Spy
+  private Clock clock;
+
   private UserEntity requestUser;
 
   private UserEntity receiverUser;
 
   private UserEntity otherUser;
 
-  private GameEntity createdGameEntity;
-  private GameEntity otherCreatedGameEntity;
+  private GameEntity createdGameEntity1;
+  private GameEntity createdGameEntity2;
 
   private ParticipantGameEntity creatorParticipantGameEntity;
 
@@ -89,9 +95,52 @@ class InviteServiceTest {
 
   private FriendEntity receiverUserFriendEntity;
 
+  private InviteEntity expectedGameCreatorRequestInviteEntity;
+  private InviteEntity expectedGameCreatorAcceptInviteEntity;
+  private InviteEntity expectedGameParticipantRequestInviteEntity;
+  private InviteEntity expectedGameParticipantAcceptInviteEntity;
+  private InviteEntity expectedGameCreatorRejectInviteEntity;
+
+  private LocalDateTime fixedRequestedDateTime;
+  private LocalDateTime fixedCanceledDateTime;
+  private LocalDateTime fixedAcceptedDateTime;
+  private LocalDateTime fixedRejectedDateTime;
+  private LocalDateTime fixedDeleteDateTime;
+
+  private CreateRequest requestInvite;
+
+  private InviteEntity requestInviteEntity;
+
+  private InviteEntity cancelInviteEntity;
+
+  private InviteEntity acceptInviteEntity;
+
+  private CancelRequest cancelInvite;
+
+  private ReceiveAcceptRequest receiveAcceptRequest;
+
+  private ReceiveRejectRequest receiveRejectRequest;
 
   @BeforeEach
   void setUp() {
+    fixedRequestedDateTime = LocalDateTime
+        .of(2024, 6, 9, 0, 0, 0);
+    fixedCanceledDateTime = LocalDateTime
+        .of(2024, 6, 10, 0, 0, 0);
+    fixedAcceptedDateTime = LocalDateTime
+        .of(2024, 6, 10, 0, 0, 0);
+    fixedRejectedDateTime = LocalDateTime
+        .of(2024, 6, 10, 0, 0, 0);
+    fixedDeleteDateTime = LocalDateTime
+        .of(2024, 6, 10, 0, 0, 0);
+    requestInvite = CreateRequest.builder()
+        .gameId(1L)
+        .receiverUserId(2L)
+        .build();
+    cancelInvite = CancelRequest.builder()
+        .inviteId(1L)
+        .gameId(1L)
+        .build();
     requestUser = UserEntity.builder()
         .id(1L)
         .loginId("test")
@@ -137,14 +186,14 @@ class InviteServiceTest {
         .createdDateTime(LocalDateTime.now())
         .emailAuth(true)
         .build();
-    createdGameEntity = GameEntity.builder()
+    createdGameEntity1 = GameEntity.builder()
         .id(1L)
         .title("테스트제목")
         .content("테스트내용")
         .headCount(6L)
         .fieldStatus(FieldStatus.INDOOR)
         .gender(Gender.ALL)
-        .startDateTime(LocalDateTime.of(2024, 10, 10, 12, 0, 0))
+        .startDateTime(LocalDateTime.now().plusHours(1))
         .inviteYn(true)
         .address("서울 마포구 와우산로13길 6 지하1,2층 (서교동)")
         .latitude(32.13123)
@@ -153,14 +202,14 @@ class InviteServiceTest {
         .cityName(CityName.SEOUL)
         .user(requestUser)
         .build();
-    otherCreatedGameEntity = GameEntity.builder()
+    createdGameEntity2 = GameEntity.builder()
         .id(2L)
         .title("테스트제목2")
         .content("테스트내용2")
         .headCount(6L)
         .fieldStatus(FieldStatus.INDOOR)
         .gender(Gender.ALL)
-        .startDateTime(LocalDateTime.of(2024, 10, 10, 12, 0, 0))
+        .startDateTime(LocalDateTime.now().plusHours(1))
         .inviteYn(true)
         .address("서울 마포구 와우산로13길 6 지하1,2층 (서교동)")
         .latitude(32.13123)
@@ -172,8 +221,7 @@ class InviteServiceTest {
     creatorParticipantGameEntity = ParticipantGameEntity.builder()
         .id(1L)
         .status(ACCEPT)
-        .createdDateTime(LocalDateTime.of(2024, 10, 10, 12, 0, 0))
-        .game(createdGameEntity)
+        .game(createdGameEntity1)
         .user(requestUser)
         .build();
     requestUserFriendEntity = FriendEntity.builder()
@@ -183,258 +231,761 @@ class InviteServiceTest {
         .friendUser(receiverUser)
         .build();
     receiverUserFriendEntity = FriendEntity.builder()
-        .id(1L)
+        .id(2L)
         .status(FriendStatus.ACCEPT)
         .user(receiverUser)
         .friendUser(requestUser)
         .build();
+    expectedGameCreatorRequestInviteEntity = InviteEntity.builder()
+        .id(1L)
+        .inviteStatus(InviteStatus.REQUEST)
+        .requestedDateTime(fixedRequestedDateTime)
+        .senderUser(requestUser)
+        .receiverUser(receiverUser)
+        .game(createdGameEntity1)
+        .build();
+    expectedGameCreatorAcceptInviteEntity = InviteEntity.builder()
+        .id(1L)
+        .inviteStatus(InviteStatus.ACCEPT)
+        .requestedDateTime(fixedRequestedDateTime)
+        .acceptedDateTime(fixedAcceptedDateTime)
+        .senderUser(requestUser)
+        .receiverUser(receiverUser)
+        .game(createdGameEntity1)
+        .build();
+    expectedGameCreatorRejectInviteEntity = InviteEntity.builder()
+        .id(1L)
+        .inviteStatus(InviteStatus.REJECT)
+        .requestedDateTime(fixedRequestedDateTime)
+        .rejectedDateTime(fixedRejectedDateTime)
+        .senderUser(requestUser)
+        .receiverUser(receiverUser)
+        .game(createdGameEntity1)
+        .build();
+        expectedGameParticipantRequestInviteEntity = InviteEntity.builder()
+        .id(1L)
+        .inviteStatus(InviteStatus.REQUEST)
+        .requestedDateTime(fixedRequestedDateTime)
+        .senderUser(receiverUser)
+        .receiverUser(otherUser)
+        .game(createdGameEntity1)
+        .build();
+    expectedGameParticipantAcceptInviteEntity = InviteEntity.builder()
+        .id(1L)
+        .inviteStatus(InviteStatus.ACCEPT)
+        .requestedDateTime(fixedRequestedDateTime)
+        .acceptedDateTime(fixedAcceptedDateTime)
+        .senderUser(receiverUser)
+        .receiverUser(otherUser)
+        .game(createdGameEntity1)
+        .build();
+
+    requestInviteEntity = CreateRequest
+        .toEntity(requestUser, receiverUser, createdGameEntity1);
+    receiveAcceptRequest = ReceiveAcceptRequest.builder()
+            .inviteId(1L)
+            .build();
+    receiveRejectRequest = ReceiveRejectRequest.builder()
+            .inviteId(1L)
+            .build();
   }
 
   @Test
   @DisplayName("경기 초대 요청 성공")
   public void requestInviteGame_success() {
     //Given
-    CreateRequest createRequest = CreateRequest.builder()
-        .gameId(1L)
-        .receiverUserId(2L)
-        .build();
 
-    CreateResponse response = CreateResponse.builder()
-        .inviteId(1L)
-        .inviteStatus(InviteStatus.REQUEST)
-        .senderUserNickName(requestUser.getNickName())
-        .receiverUserNickName(receiverUser.getNickName())
-        .title(createdGameEntity.getTitle())
-        .build();
+    // 로그인 한 유저 조회
+    getCurrentUser(requestUser);
+    
+    // 해당 경기 조회
+    getGame(requestInvite.getGameId());
 
-    InviteEntity inviteEntity = CreateRequest
-        .toEntity(requestUser, receiverUser, createdGameEntity);
+    // 해당 경기에 참가해 있는 사람이 초대할 경우를 가정
+    checkParticipantGame(createdGameEntity1.getId(), requestUser.getId(), true);
 
-    getCurrentUser();
+    // 해당 경기 인원이 경기개설자(1명 만) 있다고 가정
+    countsAcceptedGame(createdGameEntity1.getId(), 1);
 
-    validFriendUser(requestUser.getId(), createRequest.getReceiverUserId());
-
-    // 경기
-    when(gameRepository
-        .findByIdAndDeletedDateTimeNull(eq(1L)))
-        .thenReturn(Optional.ofNullable(createdGameEntity));
-
-    when(userRepository.findById(eq(2L)))
-        .thenReturn(Optional.ofNullable(receiverUser));
+    // 초대 받으려는 유저 조회
+    getReceiverUser(requestInvite.getReceiverUserId());
+    
+    // 초대 받은 사람이 친구 라고 가정
+    checkFriendUser(requestUser.getId(), receiverUser.getId(), true);
 
     // 해당 경기에 이미 초대 요청 되어 있지 않다고 가정
-    when(inviteRepository
-        .existsByInviteStatusAndGameIdAndReceiverUserId
-            (eq(InviteStatus.REQUEST), eq(1L),
-                eq(2L)))
-        .thenReturn(false);
-
-    // 해당 경기에 참가해 잇는 사람이 초대할 경우를 가정
-    when(participantGameRepository
-        .existsByStatusAndGameIdAndUserId
-            (eq(ParticipantGameStatus.ACCEPT), eq(1L), eq(1L)))
-        .thenReturn(true);
+    checkAlreadyRequestInviteGame
+        (createdGameEntity1.getId(), receiverUser.getId(), false);
 
     // 초대 받는 사람이 해당 경기에 참가 및 요청 안했을 경우를 가정
-    when(participantGameRepository
-        .existsByStatusInAndGameIdAndUserId
-            (eq(List.of(ParticipantGameStatus.ACCEPT, ParticipantGameStatus.APPLY))
-                ,eq(1L), eq(2L)))
-        .thenReturn(false);
+    checkAlreadyAcceptOrApplyGame
+        (createdGameEntity1.getId(), receiverUser.getId(), false);
 
-    // 경기 인원이 경기개설자(1명 만) 있다고 가정
-    when(participantGameRepository
-        .countByStatusAndGameId
-            (eq(ParticipantGameStatus.ACCEPT), eq(1L)))
-        .thenReturn(1);
-
-    when(inviteRepository.save(any(InviteEntity.class))).thenAnswer(invocation -> {
+    when(inviteRepository.save(requestInviteEntity)).thenAnswer(invocation -> {
       InviteEntity savedInviteEntity = invocation.getArgument(0);
       savedInviteEntity.setId(1L); // inviteId 동적 할당
-      savedInviteEntity.setRequestedDateTime(LocalDateTime.now());
+      savedInviteEntity.setRequestedDateTime(fixedRequestedDateTime);
       return savedInviteEntity;
     });
 
+    // ArgumentCaptor를 사용하여 저장된 엔티티를 캡처합니다.
+    ArgumentCaptor<InviteEntity> inviteEntityArgumentCaptor =
+        ArgumentCaptor.forClass(InviteEntity.class);
+
     // when
-    CreateResponse result = inviteService.requestInviteGame(createRequest);
+    inviteService.requestInviteGame(requestInvite);
 
     // Then
-    assertEquals(response.getInviteId(), result.getInviteId());
-    assertEquals(response.getInviteStatus(), result.getInviteStatus());
-    assertEquals(response.getSenderUserNickName(), result.getSenderUserNickName());
-    assertEquals(response.getReceiverUserNickName(), result.getReceiverUserNickName());
-    assertEquals(response.getTitle(), result.getTitle());
+    verify(inviteRepository).save(inviteEntityArgumentCaptor.capture());
+
+    // 저장된 엔티티 캡처
+    InviteEntity saveInviteEntity = inviteEntityArgumentCaptor.getValue();
+
+    assertEquals(expectedGameCreatorRequestInviteEntity, saveInviteEntity);
+  }
+
+  @Test
+  @DisplayName("경기 초대 요청 실패 : 해당 경기가 초대 불가능일 때")
+  public void requestInviteGame_failIfGameInviteNo() {
+    //Given
+    createdGameEntity1.setInviteYn(false);
+
+    // 로그인 한 유저 조회
+    getCurrentUser(requestUser);
+
+    // 해당 경기 조회
+    getGame(requestInvite.getGameId());
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      inviteService.requestInviteGame(requestInvite);
+    });
+
+    // then
+    assertEquals(ErrorCode.NOT_GAME_INVITE, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("경기 초대 요청 실패 : 경기가 이미 시작이 되었을 때")
+  public void requestInviteGame_failIfGameStarted() {
+    //Given
+    createdGameEntity1.setStartDateTime(LocalDateTime.now().minusMinutes(1));
+
+    // 로그인 한 유저 조회
+    getCurrentUser(requestUser);
+
+    // 해당 경기 조회
+    getGame(requestInvite.getGameId());
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      inviteService.requestInviteGame(requestInvite);
+    });
+
+    // then
+    assertEquals(ErrorCode.ALREADY_GAME_START, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("경기 초대 요청 실패 : 해당 경기에 참가해 있지 않은 사람이 초대를 할 경우")
+  public void requestInviteGame_failIfNotParticipantUserRequestGameInvite() {
+    //Given
+
+    // 로그인 한 유저 조회
+    getCurrentUser(requestUser);
+
+    // 해당 경기 조회
+    getGame(requestInvite.getGameId());
+
+    // 해당 경기에 참가해 있지 않은 사람이 초대할 경우를 가정
+    checkParticipantGame(createdGameEntity1.getId(), requestUser.getId(),
+        false);
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      inviteService.requestInviteGame(requestInvite);
+    });
+
+    // then
+    assertEquals(ErrorCode.NOT_PARTICIPANT_GAME, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("경기 초대 요청 실패 : 해당 경기 인원이 다 찰 경우")
+  public void requestInviteGame_failIfFulledGame() {
+    //Given
+
+    // 로그인 한 유저 조회
+    getCurrentUser(requestUser);
+
+    // 해당 경기 조회
+    getGame(requestInvite.getGameId());
+
+    // 해당 경기에 참가해 있는 사람이 초대할 경우를 가정
+    checkParticipantGame(createdGameEntity1.getId(), requestUser.getId(),
+        true);
+
+    // 해당 경기 인원이 6명 있다고 가정
+    countsAcceptedGame(createdGameEntity1.getId(), 6);
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      inviteService.requestInviteGame(requestInvite);
+    });
+
+    // then
+    assertEquals(ErrorCode.FULL_PARTICIPANT, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("경기 초대 요청 실패 : 친구가 아닌 사람이 요청할 때")
+  public void requestInviteGame_failIfNotFriendRequestInvite() {
+    //Given
+
+    // 로그인 한 유저 조회
+    getCurrentUser(requestUser);
+
+    // 해당 경기 조회
+    getGame(requestInvite.getGameId());
+
+    // 해당 경기에 참가해 있는 사람이 초대할 경우를 가정
+    checkParticipantGame(createdGameEntity1.getId(), requestUser.getId(),
+        true);
+
+    // 해당 경기 인원이 경기개설자(1명 만) 있다고 가정
+    countsAcceptedGame(createdGameEntity1.getId(), 1);
+
+    // 초대 받으려는 유저 조회
+    getReceiverUser(requestInvite.getReceiverUserId());
+
+    // 초대 받은 사람이 친구가 아니 라고 가정
+    checkFriendUser(requestUser.getId(), receiverUser.getId(), false);
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      inviteService.requestInviteGame(requestInvite);
+    });
+
+    // then
+    assertEquals(ErrorCode.NOT_FOUND_ACCEPT_FRIEND, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("경기 초대 요청 실패 : 해당 경기에 이미 초대 요청 되어 있을 때")
+  public void requestInviteGame_failIfAlreadyRequestGameInvite() {
+    //Given
+
+    // 로그인 한 유저 조회
+    getCurrentUser(requestUser);
+
+    // 해당 경기 조회
+    getGame(requestInvite.getGameId());
+
+    // 해당 경기에 참가해 있는 사람이 초대할 경우를 가정
+    checkParticipantGame(createdGameEntity1.getId(), requestUser.getId(),
+        true);
+
+    // 해당 경기 인원이 경기개설자(1명 만) 있다고 가정
+    countsAcceptedGame(createdGameEntity1.getId(), 1);
+
+    // 초대 받으려는 유저 조회
+    getReceiverUser(requestInvite.getReceiverUserId());
+
+    // 초대 받은 사람이 친구 라고 가정
+    checkFriendUser(requestUser.getId(), receiverUser.getId(), true);
+
+    // 해당 경기에 이미 초대 요청 되어 있다고 가정
+    checkAlreadyRequestInviteGame
+        (createdGameEntity1.getId(), receiverUser.getId(), true);
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      inviteService.requestInviteGame(requestInvite);
+    });
+
+    // then
+    assertEquals(ErrorCode.ALREADY_INVITE_GAME, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("경기 초대 요청 실패 : 해당 경기에 이미 참가 하거나 요청한 경우")
+  public void requestInviteGame_failIfAlreadyAcceptOrApplyGame() {
+    //Given
+
+    // 로그인 한 유저 조회
+    getCurrentUser(requestUser);
+
+    // 해당 경기 조회
+    getGame(requestInvite.getGameId());
+
+    // 해당 경기에 참가해 있는 사람이 초대할 경우를 가정
+    checkParticipantGame(createdGameEntity1.getId(), requestUser.getId(),
+        true);
+
+    // 해당 경기 인원이 경기개설자(1명 만) 있다고 가정
+    countsAcceptedGame(createdGameEntity1.getId(), 1);
+
+    // 초대 받으려는 유저 조회
+    getReceiverUser(requestInvite.getReceiverUserId());
+
+    // 초대 받은 사람이 친구 라고 가정
+    checkFriendUser(requestUser.getId(), receiverUser.getId(), true);
+
+    // 해당 경기에 이미 초대 요청 되어 있지 않다고 가정
+    checkAlreadyRequestInviteGame
+        (createdGameEntity1.getId(), receiverUser.getId(), false);
+
+    // 초대 받는 사람이 해당 경기에 참가 및 요청 했을 경우를 가정
+    checkAlreadyAcceptOrApplyGame
+        (createdGameEntity1.getId(), receiverUser.getId(), true);
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      inviteService.requestInviteGame(requestInvite);
+    });
+
+    // then
+    assertEquals(ErrorCode.ALREADY_PARTICIPANT_GAME, exception.getErrorCode());
   }
 
   @Test
   @DisplayName("경기 초대 요청 취소 성공")
-  public void cancelInviteGame_success() {
+  public void cancelInvitation_success() {
     //Given
-    CancelRequest cancelRequest = CancelRequest.builder()
-        .inviteId(1L)
-        .gameId(1L)
-        .build();
-
-    CancelResponse response = CancelResponse.builder()
-        .inviteId(1L)
-        .inviteStatus(InviteStatus.CANCEL)
-        .senderUserNickName(requestUser.getNickName())
-        .receiverUserNickName(receiverUser.getNickName())
-        .title(createdGameEntity.getTitle())
-        .build();
-
-    InviteEntity inviteEntity = InviteEntity.builder()
+    InviteEntity expectedcancelInviteEntity = InviteEntity.builder()
         .id(1L)
         .inviteStatus(InviteStatus.CANCEL)
+        .requestedDateTime(fixedRequestedDateTime)
+        .canceledDateTime(fixedCanceledDateTime)
         .senderUser(requestUser)
         .receiverUser(receiverUser)
-        .game(createdGameEntity)
+        .game(createdGameEntity1)
         .build();
 
-    getCurrentUser();
+    Instant fixedInstant = fixedCanceledDateTime.atZone(ZoneId.systemDefault())
+        .toInstant();
 
-    // 경기
-    when(inviteRepository
-        .findByIdAndInviteStatus(eq(1L), eq(InviteStatus.REQUEST)))
-        .thenReturn(Optional.ofNullable(inviteEntity));
+    when(clock.instant()).thenReturn(fixedInstant);
+    when(clock.getZone()).thenReturn(ZoneId.systemDefault());
 
-    when(inviteRepository.save(any(InviteEntity.class))).thenReturn(inviteEntity);
+    // 로그인 한 유저 조회
+    getCurrentUser(requestUser);
+
+    // 해당 초대 정보 조회
+    getGameCreatorRequestInviteEntity(cancelInvite.getInviteId());
+
+    cancelInviteEntity = InviteEntity.toCancelEntity(
+        expectedGameCreatorRequestInviteEntity, clock);
+
+    when(inviteRepository.save(cancelInviteEntity)).thenReturn(cancelInviteEntity);
 
     // when
-    CancelResponse result = inviteService.cancelInviteGame(cancelRequest);
+    inviteService.cancelInviteGame(cancelInvite);
 
     // Then
-    assertEquals(response.getInviteId(), result.getInviteId());
-    assertEquals(response.getInviteStatus(), result.getInviteStatus());
-    assertEquals(response.getSenderUserNickName(), result.getSenderUserNickName());
-    assertEquals(response.getReceiverUserNickName(), result.getReceiverUserNickName());
-    assertEquals(response.getTitle(), result.getTitle());
+    assertEquals(expectedcancelInviteEntity, cancelInviteEntity);
   }
 
   @Test
-  @DisplayName("경기 초대 요청(경기 개설자) 수락 성공")
-  public void acceptGameCreatorInviteGame_success() {
+  @DisplayName("경기 초대 요청 취소 실패 : 본인이 경기 초대 요청한 것이 아닐때")
+  public void cancelInvitation_failIfNotMyRequestInvitationToGame() {
     //Given
-    ReceiveAcceptRequest receiveAcceptRequest = ReceiveAcceptRequest.builder()
-        .inviteId(1L)
-        .build();
+    expectedGameCreatorRequestInviteEntity.assignSenderUser(receiverUser);
 
-    ReceiveAcceptResponse response = ReceiveAcceptResponse.builder()
-        .inviteId(1L)
-        .inviteStatus(InviteStatus.ACCEPT)
-        .senderUserNickName(requestUser.getNickName())
-        .receiverUserNickName(receiverUser.getNickName())
-        .title(createdGameEntity.getTitle())
-        .build();
+    // 로그인 한 유저 조회
+    getCurrentUser(requestUser);
 
-    InviteEntity inviteEntity = InviteEntity.builder()
-        .id(1L)
-        .inviteStatus(InviteStatus.REQUEST)
-        .senderUser(requestUser)
-        .receiverUser(receiverUser)
-        .game(createdGameEntity)
-        .build();
-
-    ParticipantGameEntity gameCreatorInvite =
-        ParticipantGameEntity.gameCreatorInvite(inviteEntity);
-
-    when(jwtTokenExtract.currentUser()).thenReturn(receiverUser);
-
-    when(userRepository.findById(anyLong())).thenReturn(
-        Optional.ofNullable(receiverUser));
-
-    validFriendUser(receiverUser.getId(), requestUser.getId());
-
-    when(inviteRepository.findByIdAndInviteStatus
-        (eq(1L), eq(InviteStatus.REQUEST)))
-        .thenReturn(Optional.of(inviteEntity));
-
-    // 해당 경기에 인원이 1명 있다고 가정
-    when(participantGameRepository
-        .countByStatusAndGameId(eq(ParticipantGameStatus.ACCEPT),
-            eq(1L)))
-        .thenReturn(0);
-
-    when(inviteRepository.save(any(InviteEntity.class))).thenReturn(inviteEntity);
-
-    when(participantGameRepository.save(any(ParticipantGameEntity.class)))
-        .thenReturn(gameCreatorInvite);
+    // 해당 초대 정보 조회
+    getGameCreatorRequestInviteEntity(cancelInvite.getInviteId());
 
     // when
-    ReceiveAcceptResponse result = inviteService.receiveAcceptInviteGame(receiveAcceptRequest);
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      inviteService.cancelInviteGame(cancelInvite);
+    });
+
+    // then
+    assertEquals(ErrorCode.NOT_SELF_REQUEST, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("경기 초대 요청 취소 실패 : 다른 경기 초대 요청 일때")
+  public void cancelInvitation_failIfRequestInvitationToAnotherGame() {
+    //Given
+    cancelInvite.setGameId(2L);
+
+    // 로그인 한 유저 조회
+    getCurrentUser(requestUser);
+
+    // 해당 초대 정보 조회
+    getGameCreatorRequestInviteEntity(cancelInvite.getInviteId());
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      inviteService.cancelInviteGame(cancelInvite);
+    });
+
+    // then
+    assertEquals(ErrorCode.NOT_INVITE_FOUND, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("경기 초대 요청 수락 성공 : 경기 개설자가 요청할 때")
+  public void acceptInvitation_successIfRequestByGameCreator() {
+    //Given
+    Instant fixedInstant = fixedAcceptedDateTime.atZone(ZoneId.systemDefault())
+        .toInstant();
+
+    when(clock.instant()).thenReturn(fixedInstant);
+    when(clock.getZone()).thenReturn(ZoneId.systemDefault());
+
+    LocalDateTime nowDateTime = LocalDateTime.now(clock);
+
+    ParticipantGameEntity expectedParticipantGameEntity = ParticipantGameEntity
+        .builder()
+        .id(2L)
+        .status(ACCEPT)
+        .createdDateTime(nowDateTime)
+        .acceptedDateTime(nowDateTime)
+        .game(createdGameEntity1)
+        .user(receiverUser)
+        .build();
+
+    acceptInviteEntity =
+        InviteEntity.toAcceptEntity(expectedGameCreatorRequestInviteEntity, nowDateTime);
+
+    ParticipantGameEntity gameCreatorInvite =
+        ParticipantGameEntity.gameCreatorInvite(
+            expectedGameCreatorRequestInviteEntity, nowDateTime);
+
+    // 로그인 한 유저 조회
+    getCurrentUser(receiverUser);
+
+    // 해당 초대 정보 조회
+    getGameCreatorRequestInviteEntity(receiveAcceptRequest.getInviteId());
+
+    // 초대 한 사람이 친구 라고 가정
+    checkFriendUser(receiverUser.getId(),
+        expectedGameCreatorRequestInviteEntity.getSenderUser().getId(), true);
+
+    // 초대한 사람이 해당 경기에 참가해 있다고 가정
+    checkParticipantGame(createdGameEntity1.getId(),
+        expectedGameCreatorRequestInviteEntity.getSenderUser().getId(), true);
+
+    // 해당 경기 인원이 경기개설자(1명 만) 있다고 가정
+    countsAcceptedGame(expectedGameCreatorRequestInviteEntity.getGame().getId(), 1);
+
+    // 수락 하는 사람이 해당 경기에 참가 및 요청 안했을 경우를 가정
+    checkAlreadyAcceptOrApplyGame
+        (createdGameEntity1.getId(), receiverUser.getId(), false);
+
+    when(inviteRepository.save(acceptInviteEntity)).thenReturn(acceptInviteEntity);
+
+    // 경기 개설자가 초대 한 경우 수락 -> 경기 참가
+    when(participantGameRepository.save(gameCreatorInvite)).thenAnswer(invocation -> {
+      ParticipantGameEntity savedParticipantGameEntity =
+          invocation.getArgument(0);
+      savedParticipantGameEntity.setId(2L); // id 동적 할당
+      return savedParticipantGameEntity;
+    });
+
+    // ArgumentCaptor를 사용하여 저장된 엔티티를 캡처합니다.
+    ArgumentCaptor<ParticipantGameEntity> participantGameEntityArgumentCaptor =
+        ArgumentCaptor.forClass(ParticipantGameEntity.class);
+
+    // when
+    inviteService.receiveAcceptInviteGame(receiveAcceptRequest);
 
     // Then
-    assertEquals(response.getInviteId(), result.getInviteId());
-    assertEquals(response.getInviteStatus(), result.getInviteStatus());
-    assertEquals(response.getSenderUserNickName(), result.getSenderUserNickName());
-    assertEquals(response.getReceiverUserNickName(), result.getReceiverUserNickName());
-    assertEquals(response.getTitle(), result.getTitle());
+    verify(participantGameRepository)
+        .save(participantGameEntityArgumentCaptor.capture());
+
+    // 저장된 엔티티 캡처
+    ParticipantGameEntity participantGameEntity =
+        participantGameEntityArgumentCaptor.getValue();
+
+    assertEquals(expectedGameCreatorAcceptInviteEntity, acceptInviteEntity);
+    assertEquals(expectedParticipantGameEntity, participantGameEntity);
+  }
+
+  @Test
+  @DisplayName("경기 초대 요청 수락 성공 : 팀원이 초대한 경우")
+  public void acceptInvitation_successIfRequestByGameParticipant() {
+    //Given
+    Instant fixedInstant = fixedAcceptedDateTime.atZone(ZoneId.systemDefault())
+        .toInstant();
+
+    when(clock.instant()).thenReturn(fixedInstant);
+    when(clock.getZone()).thenReturn(ZoneId.systemDefault());
+
+    LocalDateTime nowDateTime = LocalDateTime.now(clock);
+
+    ParticipantGameEntity expectedParticipantGameEntity = ParticipantGameEntity
+        .builder()
+        .id(3L)
+        .status(APPLY)
+        .createdDateTime(nowDateTime)
+        .acceptedDateTime(nowDateTime)
+        .game(createdGameEntity1)
+        .user(otherUser)
+        .build();
+
+    acceptInviteEntity =
+        InviteEntity.toAcceptEntity(expectedGameParticipantRequestInviteEntity, nowDateTime);
+
+    ParticipantGameEntity gameUserInvite =
+        ParticipantGameEntity.gameUserInvite(
+            expectedGameParticipantRequestInviteEntity);
+
+    // 로그인 한 유저 조회
+    getCurrentUser(otherUser);
+
+    // 해당 초대 정보 조회
+    getGameParticipantRequestInviteEntity(receiveAcceptRequest.getInviteId());
+
+    // 초대 한 사람이 친구 라고 가정
+    checkFriendUser(otherUser.getId(),
+        expectedGameParticipantRequestInviteEntity.getSenderUser().getId(), true);
+
+    // 초대한 사람이 해당 경기에 참가해 있다고 가정
+    checkParticipantGame(createdGameEntity1.getId(),
+        expectedGameParticipantRequestInviteEntity.getSenderUser().getId(), true);
+
+    // 해당 경기 인원이 경기개설자(1명 만) 있다고 가정
+    countsAcceptedGame(expectedGameCreatorRequestInviteEntity.getGame().getId(), 1);
+
+    // 수락 하는 사람이 해당 경기에 참가 및 요청 안했을 경우를 가정
+    checkAlreadyAcceptOrApplyGame
+        (createdGameEntity1.getId(), otherUser.getId(), false);
+
+    when(inviteRepository.save(acceptInviteEntity)).thenReturn(acceptInviteEntity);
+    // 경기 개설자가 초대 한 경우 수락 -> 경기 참가
+    when(participantGameRepository.save(gameUserInvite)).thenAnswer(invocation -> {
+      ParticipantGameEntity savedParticipantGameEntity =
+          invocation.getArgument(0);
+      savedParticipantGameEntity.setId(3L); // id 동적 할당
+      savedParticipantGameEntity.setCreatedDateTime(nowDateTime);
+      return savedParticipantGameEntity;
+    });
+
+    // ArgumentCaptor를 사용하여 저장된 엔티티를 캡처합니다.
+    ArgumentCaptor<ParticipantGameEntity> participantGameEntityArgumentCaptor =
+        ArgumentCaptor.forClass(ParticipantGameEntity.class);
+
+    // when
+    inviteService.receiveAcceptInviteGame(receiveAcceptRequest);
+
+    // Then
+    verify(participantGameRepository)
+        .save(participantGameEntityArgumentCaptor.capture());
+
+    // 저장된 엔티티 캡처
+    ParticipantGameEntity participantGameEntity =
+        participantGameEntityArgumentCaptor.getValue();
+
+    assertEquals(expectedGameParticipantAcceptInviteEntity, acceptInviteEntity);
+    assertEquals(expectedParticipantGameEntity, participantGameEntity);
+  }
+
+  @Test
+  @DisplayName("경기 초대 요청 수락 실패 : 본인이 받은 초대 요청이 아닐때")
+  public void acceptInvitation_failIfNotMyRequestInvite() {
+    //Given
+    expectedGameCreatorRequestInviteEntity.assignReceiverUser(requestUser);
+
+    // 로그인 한 유저 조회
+    getCurrentUser(receiverUser);
+
+    // 해당 초대 정보 조회
+    getGameCreatorRequestInviteEntity(receiveAcceptRequest.getInviteId());
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      inviteService.receiveAcceptInviteGame(receiveAcceptRequest);
+    });
+
+    // then
+    assertEquals(ErrorCode.NOT_SELF_INVITE_REQUEST, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("경기 초대 요청 수락 실패 : 친구가 아닌 사람이 초대 요청 했을때")
+  public void acceptInvitation_failIfNotFriendRequestInvite() {
+    //Given
+
+    // 로그인 한 유저 조회
+    getCurrentUser(receiverUser);
+
+    // 해당 초대 정보 조회
+    getGameCreatorRequestInviteEntity(receiveAcceptRequest.getInviteId());
+
+    // 초대 한 사람이 친구가 아니 라고 가정
+    checkFriendUser(receiverUser.getId(),
+        expectedGameCreatorRequestInviteEntity.getSenderUser().getId(), false);
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      inviteService.receiveAcceptInviteGame(receiveAcceptRequest);
+    });
+
+    // then
+    assertEquals(ErrorCode.NOT_FOUND_ACCEPT_FRIEND, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("경기 초대 요청 수락 실패 : 초대한 사람이 해당 경기에 참가해 있지 않을 때")
+  public void acceptInvitation_failIfSenderUserNotParticipantGame() {
+    //Given
+
+    // 로그인 한 유저 조회
+    getCurrentUser(receiverUser);
+
+    // 해당 초대 정보 조회
+    getGameCreatorRequestInviteEntity(receiveAcceptRequest.getInviteId());
+
+    // 초대 한 사람이 친구 라고 가정
+    checkFriendUser(receiverUser.getId(),
+        expectedGameCreatorRequestInviteEntity.getSenderUser().getId(), true);
+
+    // 초대한 사람이 해당 경기에 참가해 있지 않다고 가정
+    checkParticipantGame(createdGameEntity1.getId(),
+        expectedGameCreatorRequestInviteEntity.getSenderUser().getId(), false);
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      inviteService.receiveAcceptInviteGame(receiveAcceptRequest);
+    });
+
+    // then
+    assertEquals(ErrorCode.NOT_PARTICIPANT_GAME, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("경기 초대 요청 수락 실패 : 해당 경기에 인원이 다 찼을 때")
+  public void acceptInvitation_failIfFulledGame() {
+    //Given
+
+    // 로그인 한 유저 조회
+    getCurrentUser(receiverUser);
+
+    // 해당 초대 정보 조회
+    getGameCreatorRequestInviteEntity(receiveAcceptRequest.getInviteId());
+
+    // 초대 한 사람이 친구 라고 가정
+    checkFriendUser(receiverUser.getId(),
+        expectedGameCreatorRequestInviteEntity.getSenderUser().getId(), true);
+
+    // 초대한 사람이 해당 경기에 참가해 있지 않다고 가정
+    checkParticipantGame(createdGameEntity1.getId(),
+        expectedGameCreatorRequestInviteEntity.getSenderUser().getId(), true);
+
+    // 해당 경기 인원이 다 찼다고 가정
+    countsAcceptedGame(expectedGameCreatorRequestInviteEntity.getGame().getId(), 6);
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      inviteService.receiveAcceptInviteGame(receiveAcceptRequest);
+    });
+
+    // then
+    assertEquals(ErrorCode.FULL_PARTICIPANT, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("경기 초대 요청 수락 실패 : 수락 하는 사람이 해당 경기에 참가 및 요청 했을 때")
+  public void acceptInvitation_failIfApplyOrAcceptGame() {
+    //Given
+
+    // 로그인 한 유저 조회
+    getCurrentUser(receiverUser);
+
+    // 해당 초대 정보 조회
+    getGameCreatorRequestInviteEntity(receiveAcceptRequest.getInviteId());
+
+    // 초대 한 사람이 친구 라고 가정
+    checkFriendUser(receiverUser.getId(),
+        expectedGameCreatorRequestInviteEntity.getSenderUser().getId(), true);
+
+    // 초대한 사람이 해당 경기에 참가해 있지 않다고 가정
+    checkParticipantGame(createdGameEntity1.getId(),
+        expectedGameCreatorRequestInviteEntity.getSenderUser().getId(), true);
+
+    // 해당 경기 인원이 경기개설자(1명 만) 있다고 가정
+    countsAcceptedGame(expectedGameCreatorRequestInviteEntity.getGame().getId(), 1);
+
+    // 수락 하는 사람이 해당 경기에 참가 및 요청 했을 경우를 가정
+    checkAlreadyAcceptOrApplyGame
+        (createdGameEntity1.getId(), receiverUser.getId(), true);
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      inviteService.receiveAcceptInviteGame(receiveAcceptRequest);
+    });
+
+    // then
+    assertEquals(ErrorCode.ALREADY_PARTICIPANT_GAME, exception.getErrorCode());
   }
 
   @Test
   @DisplayName("경기 초대 요청 거절 성공")
-  public void rejectInviteGame_success() {
+  public void rejectInvitation_success() {
     //Given
-    ReceiveRejectRequest receiveRejectRequest = ReceiveRejectRequest.builder()
-        .inviteId(1L)
-        .build();
+    Instant fixedInstant = fixedRejectedDateTime.atZone(ZoneId.systemDefault())
+        .toInstant();
 
-    ReceiveRejectResponse response = ReceiveRejectResponse.builder()
-        .inviteId(1L)
-        .inviteStatus(InviteStatus.REJECT)
-        .senderUserNickName(requestUser.getNickName())
-        .receiverUserNickName(receiverUser.getNickName())
-        .title(createdGameEntity.getTitle())
-        .build();
+    when(clock.instant()).thenReturn(fixedInstant);
+    when(clock.getZone()).thenReturn(ZoneId.systemDefault());
 
-    InviteEntity inviteEntity = InviteEntity.builder()
-        .id(1L)
-        .inviteStatus(InviteStatus.REQUEST)
-        .senderUser(requestUser)
-        .receiverUser(receiverUser)
-        .game(createdGameEntity)
-        .build();
+    // 로그인 한 유저 조회
+    getCurrentUser(receiverUser);
 
-    InviteEntity rejectEntity = InviteEntity.builder()
-        .id(1L)
-        .inviteStatus(InviteStatus.REJECT)
-        .senderUser(requestUser)
-        .receiverUser(receiverUser)
-        .game(createdGameEntity)
-        .build();
+    // 해당 초대 정보 조회
+    getGameCreatorRequestInviteEntity(receiveRejectRequest.getInviteId());
 
-    when(jwtTokenExtract.currentUser()).thenReturn(receiverUser);
+    InviteEntity rejectEntity = InviteEntity.toRejectEntity
+        (expectedGameCreatorRequestInviteEntity, clock);
 
-    when(userRepository.findById(anyLong())).thenReturn(
-        Optional.ofNullable(receiverUser));
 
-    when(inviteRepository.findByIdAndInviteStatus
-        (eq(1L), eq(InviteStatus.REQUEST)))
-        .thenReturn(Optional.of(inviteEntity));
-
-    when(inviteRepository.save(any(InviteEntity.class))).thenReturn(rejectEntity);
+    when(inviteRepository.save(rejectEntity))
+        .thenReturn(rejectEntity);
 
     // when
-    ReceiveRejectResponse result = inviteService.receiveRejectInviteGame(receiveRejectRequest);
+    inviteService.receiveRejectInviteGame(receiveRejectRequest);
 
     // Then
-    assertEquals(response.getInviteId(), result.getInviteId());
-    assertEquals(response.getInviteStatus(), result.getInviteStatus());
-    assertEquals(response.getSenderUserNickName(), result.getSenderUserNickName());
-    assertEquals(response.getReceiverUserNickName(), result.getReceiverUserNickName());
-    assertEquals(response.getTitle(), result.getTitle());
+    assertEquals(expectedGameCreatorRejectInviteEntity ,rejectEntity);
+  }
+
+  @Test
+  @DisplayName("경기 초대 요청 거절 실패 : 본인이 받은 초대 요청이 아닐때")
+  public void rejectInvitation_failIfNotMyRequestInvitation() {
+    //Given
+    expectedGameCreatorRequestInviteEntity.assignReceiverUser(requestUser);
+
+    // 로그인 한 유저 조회
+    getCurrentUser(receiverUser);
+
+    // 해당 초대 정보 조회
+    getGameCreatorRequestInviteEntity(receiveRejectRequest.getInviteId());
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      inviteService.receiveRejectInviteGame(receiveRejectRequest);
+    });
+
+    // then
+    assertEquals(ErrorCode.NOT_SELF_INVITE_REQUEST, exception.getErrorCode());
   }
 
   @Test
   @DisplayName("경기 초대 요청 리스트 조회 성공")
-  public void getInviteRequestList_success() {
+  public void getRequestInvitationList_success() {
     //Given
     InviteEntity inviteEntity1 = InviteEntity.builder()
         .id(1L)
         .inviteStatus(InviteStatus.REQUEST)
         .senderUser(requestUser)
         .receiverUser(otherUser)
-        .game(createdGameEntity)
+        .game(createdGameEntity1)
         .build();
 
     InviteEntity inviteEntity2 = InviteEntity.builder()
@@ -442,53 +993,109 @@ class InviteServiceTest {
         .inviteStatus(InviteStatus.REQUEST)
         .senderUser(receiverUser)
         .receiverUser(otherUser)
-        .game(otherCreatedGameEntity)
+        .game(createdGameEntity2)
         .build();
 
-    List<InviteEntity> inviteEntityList = new ArrayList<>();
-    inviteEntityList.add(inviteEntity1);
-    inviteEntityList.add(inviteEntity2);
+    List<InviteEntity> inviteEntityList = List.of(inviteEntity1, inviteEntity2);
 
-    List<InviteMyListResponse> responseList = inviteEntityList.stream()
+    List<InviteMyListResponse> expectList = inviteEntityList.stream()
         .map(InviteMyListResponse::toDto)
         .toList();
 
-    when(jwtTokenExtract.currentUser()).thenReturn(otherUser);
-
-    when(userRepository.findById(anyLong())).thenReturn(
-        Optional.ofNullable(otherUser));
+    // 로그인 한 유저 조회
+    getCurrentUser(otherUser);
 
     when(inviteRepository.findByInviteStatusAndReceiverUserId
-        (eq(InviteStatus.REQUEST), anyLong()))
+        (InviteStatus.REQUEST, otherUser.getId()))
         .thenReturn(inviteEntityList);
 
     // when
     List<InviteMyListResponse> result = inviteService.getInviteRequestList();
 
     // Then
-    assertEquals(responseList.get(0).getInviteId(), result.get(0).getInviteId());
-    assertEquals(responseList.get(0).getInviteStatus(), result.get(0).getInviteStatus());
-    assertEquals(responseList.get(0).getGameId(), result.get(0).getGameId());
-
-    assertEquals(responseList.get(1).getInviteId(),
-        result.get(1).getInviteId());
-    assertEquals(responseList.get(1).getInviteStatus(),
-        result.get(1).getInviteStatus());
-    assertEquals(responseList.get(1).getGameId(), result.get(1).getGameId());
+    assertEquals(expectList, result);
   }
 
+  // 로그인 유저 조회
+  private void getCurrentUser(UserEntity userEntity) {
+    when(jwtTokenExtract.currentUser()).thenReturn(userEntity);
 
-
-  private void getCurrentUser() {
-    when(jwtTokenExtract.currentUser()).thenReturn(requestUser);
-
-    when(userRepository.findById(anyLong())).thenReturn(
-        Optional.ofNullable(requestUser));
+    when(userRepository.findById(userEntity.getId())).thenReturn(
+        Optional.of(userEntity));
   }
 
-  private void validFriendUser(Long senderUserId, Long receiverUserId) {
+  // 해당 경기 조회
+  private void getGame(Long gameId) {
+    when(gameRepository
+        .findByIdAndDeletedDateTimeNull(gameId))
+        .thenReturn(Optional.ofNullable(createdGameEntity1));
+  }
+
+  // 해당 경기에 참가 했는지 검사
+  private void checkParticipantGame(Long gameId, Long userId, boolean flag) {
+    when(participantGameRepository
+        .existsByStatusAndGameIdAndUserId
+            (ParticipantGameStatus.ACCEPT, gameId, userId))
+        .thenReturn(flag);
+  }
+
+  // 해당 경기에 인원수를 검사
+  private void countsAcceptedGame(Long gameId, int count) {
+    when(participantGameRepository
+        .countByStatusAndGameId
+            (ParticipantGameStatus.ACCEPT, gameId))
+        .thenReturn(count);
+  }
+
+  // 초대 받으려는 유저 조회
+  private void getReceiverUser(Long receiverUserId) {
+    when(userRepository
+        .findById(receiverUserId))
+        .thenReturn(Optional.ofNullable(receiverUser));
+  }
+
+  // 초대 받은 사람이 친구 인지 검사
+  private void checkFriendUser(Long senderUserId, Long receiverUserId,
+      boolean flag) {
     when(friendRepository.existsByUserIdAndFriendUserIdAndStatus
-        (senderUserId, receiverUserId, FriendStatus.ACCEPT)).thenReturn(true);
+        (senderUserId, receiverUserId, FriendStatus.ACCEPT)).thenReturn(flag);
   }
+
+  // 해당 경기에 이미 초대 요청 되어 있는지 검사
+  private void checkAlreadyRequestInviteGame(Long gameId, Long receiverUserId,
+      boolean flag) {
+    when(inviteRepository
+        .existsByInviteStatusAndGameIdAndReceiverUserId
+            (InviteStatus.REQUEST, gameId, receiverUserId))
+        .thenReturn(flag);
+  }
+
+  // 초대 받는 사람이 해당 경기에 참가 및 요청 되어 있는지 검사
+  private void checkAlreadyAcceptOrApplyGame(Long gameId, Long userId,
+      boolean flag) {
+    when(participantGameRepository
+        .existsByStatusInAndGameIdAndUserId
+            (List.of(ParticipantGameStatus.ACCEPT, ParticipantGameStatus.APPLY),
+                 gameId, userId))
+        .thenReturn(flag);
+  }
+
+  // 경기 개설자 초대 정보 조회
+  private void getGameCreatorRequestInviteEntity(Long inviteId) {
+    when(inviteRepository
+        .findByIdAndInviteStatus(inviteId, InviteStatus.REQUEST))
+        .thenReturn(Optional.ofNullable(
+            expectedGameCreatorRequestInviteEntity));
+  }
+
+  // 경기 팀원 초대 정보 조회
+  private void getGameParticipantRequestInviteEntity(Long inviteId) {
+    when(inviteRepository
+        .findByIdAndInviteStatus(inviteId, InviteStatus.REQUEST))
+        .thenReturn(Optional.ofNullable(
+            expectedGameParticipantRequestInviteEntity));
+  }
+
+
 
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**
- InviteServiceTest any() 사용 및 실패케이스 없음
    - 해당 dto, entity / equals, hashCode 없음
    - LocalDateTime.now()
**TO-BE**
- InviteServiceTest any() 삭제 및 실패 케이스 작성
    - 해당 dto, entity / equals, hashCode 작성
    - LocalDateTime.now(clock) 반영
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [V] 테스트 코드
- [ ] API 테스트 