### PR TITLE
[리펙토링] 기존 채팅방에 유저가 다시 접속할 경우 메세지 중복 표시 수정

### DIFF
--- a/src/main/generated/com/zerobase/hoops/entity/QChatRoomEntity.java
+++ b/src/main/generated/com/zerobase/hoops/entity/QChatRoomEntity.java
@@ -26,7 +26,7 @@ public class QChatRoomEntity extends EntityPathBase<ChatRoomEntity> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
-    public final NumberPath<Long> sessionId = createNumber("sessionId", Long.class);
+    public final QUserEntity userEntity;
 
     public QChatRoomEntity(String variable) {
         this(ChatRoomEntity.class, forVariable(variable), INITS);
@@ -47,6 +47,7 @@ public class QChatRoomEntity extends EntityPathBase<ChatRoomEntity> {
     public QChatRoomEntity(Class<? extends ChatRoomEntity> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
         this.gameEntity = inits.isInitialized("gameEntity") ? new QGameEntity(forProperty("gameEntity"), inits.get("gameEntity")) : null;
+        this.userEntity = inits.isInitialized("userEntity") ? new QUserEntity(forProperty("userEntity")) : null;
     }
 
 }

--- a/src/main/generated/com/zerobase/hoops/entity/QMessageEntity.java
+++ b/src/main/generated/com/zerobase/hoops/entity/QMessageEntity.java
@@ -30,8 +30,6 @@ public class QMessageEntity extends EntityPathBase<MessageEntity> {
 
     public final DateTimePath<java.time.LocalDateTime> sendDateTime = createDateTime("sendDateTime", java.time.LocalDateTime.class);
 
-    public final NumberPath<Long> sessionId = createNumber("sessionId", Long.class);
-
     public final QUserEntity user;
 
     public QMessageEntity(String variable) {

--- a/src/main/java/com/zerobase/hoops/chat/chat/ChatMessage.java
+++ b/src/main/java/com/zerobase/hoops/chat/chat/ChatMessage.java
@@ -10,9 +10,5 @@ public class ChatMessage {
   private MessageType type;
   private String content;
   private String sender;
-  private Long sessionId;
 
-  public void changeNewSessionId(Long newSessionId) {
-    this.sessionId = newSessionId;
-  }
 }

--- a/src/main/java/com/zerobase/hoops/chat/controller/ChatController.java
+++ b/src/main/java/com/zerobase/hoops/chat/controller/ChatController.java
@@ -7,7 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ChatController {
 
-  private final SimpMessagingTemplate messagingTemplate;
   private final ChatService chatService;
 
   @MessageMapping("/sendMessage/{gameId}")

--- a/src/main/java/com/zerobase/hoops/chat/dto/MessageConvertDto.java
+++ b/src/main/java/com/zerobase/hoops/chat/dto/MessageConvertDto.java
@@ -17,7 +17,4 @@ public class MessageConvertDto {
   @NotBlank
   private String content;
 
-  @NotBlank
-  private Long sessionId;
-
 }

--- a/src/main/java/com/zerobase/hoops/chat/dto/MessageDto.java
+++ b/src/main/java/com/zerobase/hoops/chat/dto/MessageDto.java
@@ -15,13 +15,9 @@ public class MessageDto {
   @NotBlank
   private String content;
 
-  @NotBlank
-  private Long sessionId;
-
   public MessageEntity toEntity(UserEntity user, ChatRoomEntity chatRoom) {
     return MessageEntity.builder()
         .user(user)
-        .sessionId(sessionId)
         .content(content)
         .chatRoomEntity(chatRoom)
         .sendDateTime(LocalDateTime.now())

--- a/src/main/java/com/zerobase/hoops/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/zerobase/hoops/chat/repository/ChatRoomRepository.java
@@ -1,6 +1,7 @@
 package com.zerobase.hoops.chat.repository;
 
 import com.zerobase.hoops.entity.ChatRoomEntity;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,5 +10,10 @@ import org.springframework.stereotype.Repository;
 public interface ChatRoomRepository extends
     JpaRepository<ChatRoomEntity, Long> {
 
-  Optional<ChatRoomEntity> findByGameEntity_Id(Long gameId);
+  boolean existsByGameEntity_IdAndUserEntity_Id(Long gameId, Long userId);
+
+  List<ChatRoomEntity> findByGameEntity_Id(Long id);
+
+  Optional<ChatRoomEntity> findByGameEntity_IdAndUserEntity_Id(Long id, Long id1);
+
 }

--- a/src/main/java/com/zerobase/hoops/chat/repository/MessageRepository.java
+++ b/src/main/java/com/zerobase/hoops/chat/repository/MessageRepository.java
@@ -1,8 +1,8 @@
 package com.zerobase.hoops.chat.repository;
 
+import com.zerobase.hoops.entity.ChatRoomEntity;
 import com.zerobase.hoops.entity.MessageEntity;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,6 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface MessageRepository extends
     JpaRepository<MessageEntity, Long> {
 
-  Optional<List<MessageEntity>> findByChatRoomEntity_IdAndSessionId(
-      Long id, Long sessionId);
+  List<MessageEntity> findByChatRoomEntity(ChatRoomEntity chatRoomEntity);
+
 }

--- a/src/main/java/com/zerobase/hoops/config/WebSocketConnectionEventListener.java
+++ b/src/main/java/com/zerobase/hoops/config/WebSocketConnectionEventListener.java
@@ -2,31 +2,81 @@ package com.zerobase.hoops.config;
 
 import com.zerobase.hoops.chat.chat.ChatMessage;
 import com.zerobase.hoops.chat.chat.MessageType;
+import com.zerobase.hoops.chat.repository.ChatRoomRepository;
+import com.zerobase.hoops.entity.ChatRoomEntity;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class WebSocketConnectionEventListener {
 
   private final SimpMessageSendingOperations messageTemplate;
+  private final ChatRoomRepository chatRoomRepository;
 
   @EventListener
-  public void handleWebSocketDisconnectListener(SessionDisconnectEvent event){
-    StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
-    String username = (String)headerAccessor.getSessionAttributes().get("username");
-    String gameId = (String) headerAccessor.getSessionAttributes().get("gameId");
+  public void handleWebSocketConnectListener(SessionConnectEvent event) {
+    StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(
+        event.getMessage());
+    String sessionId = headerAccessor.getSessionId();
+    String nickName = headerAccessor.getFirstNativeHeader("nickName");
+    String gameId = headerAccessor.getFirstNativeHeader("gameId");
+    log.info("headerAccessor{}", headerAccessor);
+    log.info("Connect event: sessionId={}, nickName={}, gameId={}",
+        sessionId, nickName, gameId);
 
-    if (username != null && gameId != null) {
-      ChatMessage chatMessage = ChatMessage.builder()
-          .type(MessageType.LEAVE)
-          .sender(username)
-          .build();
-      messageTemplate.convertAndSend("/topic/" + gameId, chatMessage);
+    if (nickName != null && gameId != null) {
+      if (headerAccessor.getSessionAttributes() == null) {
+        headerAccessor.setSessionAttributes(new ConcurrentHashMap<>());
+      }
+      headerAccessor.getSessionAttributes().put("nickName", nickName);
+      headerAccessor.getSessionAttributes().put("gameId", gameId);
+      log.info(
+          "Session attributes set: sessionId={}, nickName={}, gameId={}",
+          sessionId, nickName, gameId);
+    } else {
+      log.error("NickName or GameId is null");
+    }
+  }
+
+  @EventListener
+  public void handleWebSocketDisconnectListener(
+      SessionDisconnectEvent event) {
+    StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(
+        event.getMessage());
+    Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
+    if (sessionAttributes != null) {
+      String username = (String) sessionAttributes.get("nickName");
+      String gameId = (String) sessionAttributes.get("gameId");
+      Long gameIdNumber = Long.parseLong(gameId);
+      log.info("username={}", username);
+      log.info("gameId={}", gameIdNumber);
+      if (username != null) {
+        List<ChatRoomEntity> chatRoomEntityList = chatRoomRepository.findByGameEntity_Id(
+            gameIdNumber);
+        for (ChatRoomEntity chatRoomEntity : chatRoomEntityList) {
+          String nickName = chatRoomEntity.getUserEntity().getNickName();
+          ChatMessage chatMessage = ChatMessage.builder()
+              .type(MessageType.LEAVE)
+              .sender(username)
+              .build();
+          messageTemplate.convertAndSend(
+              "/topic/" + gameId + "/" + nickName,
+              chatMessage);
+        }
+      }
+    } else {
+      log.error("Session attributes are null");
     }
   }
 }

--- a/src/main/java/com/zerobase/hoops/entity/ChatRoomEntity.java
+++ b/src/main/java/com/zerobase/hoops/entity/ChatRoomEntity.java
@@ -6,7 +6,6 @@ import lombok.*;
 
 @Entity(name = "chat_room")
 @Getter
-@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -16,31 +15,33 @@ public class ChatRoomEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Builder.Default
-  @Column(nullable = false)
-  private Long sessionId = 0L;
-
-  @OneToOne
+  @ManyToOne
   private GameEntity gameEntity;
+
+  @ManyToOne
+  private UserEntity userEntity;
 
   public void saveGameInfo(GameEntity game){
     this.gameEntity = game;
   }
-  public void changeNewSessionId(Long newSessionId){
-    this.sessionId = newSessionId;
+  public void saveUserInfo(UserEntity user){
+    this.userEntity = user;
   }
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     ChatRoomEntity that = (ChatRoomEntity) o;
-    return Objects.equals(id, that.id) &&
-        Objects.equals(gameEntity, that.gameEntity);
+    return Objects.equals(id, that.id);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, gameEntity);
+    return Objects.hash(id);
   }
 }

--- a/src/main/java/com/zerobase/hoops/entity/MannerPointEntity.java
+++ b/src/main/java/com/zerobase/hoops/entity/MannerPointEntity.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -44,5 +45,22 @@ public class MannerPointEntity {
 
   @CreatedDate
   private LocalDateTime createdDateTime;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MannerPointEntity that = (MannerPointEntity) o;
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
 
 }

--- a/src/main/java/com/zerobase/hoops/entity/MessageEntity.java
+++ b/src/main/java/com/zerobase/hoops/entity/MessageEntity.java
@@ -7,9 +7,9 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,10 +29,6 @@ public class MessageEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Builder.Default
-  @Column(nullable = false)
-  private Long sessionId = 0L;
-
   @Column(columnDefinition = "TEXT")
   private String content;
 
@@ -46,5 +42,20 @@ public class MessageEntity {
   @ManyToOne(fetch = FetchType.EAGER)
   private ChatRoomEntity chatRoomEntity;
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MessageEntity that = (MessageEntity) o;
+    return Objects.equals(id, that.id);
+  }
 
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
 }

--- a/src/main/java/com/zerobase/hoops/gameCreator/repository/GameRepository.java
+++ b/src/main/java/com/zerobase/hoops/gameCreator/repository/GameRepository.java
@@ -15,12 +15,15 @@ public interface GameRepository extends
 
   List<GameEntity> findByUserIdAndDeletedDateTimeNull(Long userId);
 
+
+
   boolean existsByStartDateTimeBetweenAndAddressAndDeletedDateTimeNull(
       LocalDateTime beforeDatetime,
       LocalDateTime afterDateTime, String address);
 
   boolean existsByStartDateTimeBetweenAndAddressAndDeletedDateTimeNullAndIdNot(
       LocalDateTime beforeDatetime, LocalDateTime afterDateTime, String address, Long gameId);
+
 }
 
 

--- a/src/main/java/com/zerobase/hoops/security/JwtTokenExtract.java
+++ b/src/main/java/com/zerobase/hoops/security/JwtTokenExtract.java
@@ -25,7 +25,7 @@ public class JwtTokenExtract {
   public UserEntity currentUser() {
     Authentication authentication = SecurityContextHolder.getContext()
         .getAuthentication();
-
+    log.info("JwtTokenExtract - currentUser value = {}", authentication);
     if (authentication == null || !authentication.isAuthenticated()
         || authentication.getPrincipal() == null) {
       throw new CustomException(ErrorCode.EXPIRED_TOKEN);
@@ -38,9 +38,10 @@ public class JwtTokenExtract {
   }
 
   public UserEntity getUserFromToken(String authorizationHeader) {
+    log.info("JwtTokenExtract - getUserFromToken value = {}",
+        authorizationHeader);
     if (authorizationHeader == null || !authorizationHeader.startsWith(
         "Bearer ")) {
-      log.info("getUserFromToken 안됨" + authorizationHeader);
       throw new CustomException(ErrorCode.INVALID_TOKEN);
     }
     String token = authorizationHeader.substring(7);

--- a/src/test/java/com/zerobase/hoops/gameCreator/service/GameServiceTest.java
+++ b/src/test/java/com/zerobase/hoops/gameCreator/service/GameServiceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.zerobase.hoops.chat.repository.ChatRoomRepository;
-import com.zerobase.hoops.entity.ChatRoomEntity;
 import com.zerobase.hoops.entity.GameEntity;
 import com.zerobase.hoops.entity.InviteEntity;
 import com.zerobase.hoops.entity.ParticipantGameEntity;
@@ -65,9 +64,6 @@ class GameServiceTest {
   @Mock
   private InviteRepository inviteRepository;
 
-  @Mock
-  private ChatRoomRepository chatRoomRepository;
-
   @Spy
   private Clock clock;
 
@@ -82,8 +78,6 @@ class GameServiceTest {
   private GameEntity expectedOtherCreatedGame;
 
   private ParticipantGameEntity expectedCreatorParticipantGame;
-
-  private ChatRoomEntity expectedCreatedChatRoom;
 
   private LocalDateTime fixedStartDateTime;
   private LocalDateTime fixedCreatedDateTime;
@@ -189,10 +183,6 @@ class GameServiceTest {
         .game(expectedCreatedGame)
         .user(requestUser)
         .build();
-    expectedCreatedChatRoom = ChatRoomEntity.builder()
-        .id(1L)
-        .gameEntity(expectedCreatedGame)
-        .build();
 
   }
 
@@ -228,9 +218,6 @@ class GameServiceTest {
         new ParticipantGameEntity().toGameCreatorEntity
             (game, requestUser, clock);
 
-    ChatRoomEntity createdChatRoom = ChatRoomEntity.builder()
-        .gameEntity(game)
-        .build();
 
     // 이미 예정된 게임이 없는 상황을 가정
     checkGame(createRequest.getStartDateTime(), createRequest.getAddress(),
@@ -245,12 +232,6 @@ class GameServiceTest {
       return entity;
     });
 
-    when(chatRoomRepository.save(createdChatRoom)).thenAnswer(invocation -> {
-      ChatRoomEntity entity = invocation.getArgument(0);
-      entity.setId(1L); // id 할당
-      return entity;
-    });
-
     // when
     gameService.validCreateGame(createRequest, requestUser);
 
@@ -261,25 +242,21 @@ class GameServiceTest {
         = ArgumentCaptor.forClass(GameEntity.class);
     ArgumentCaptor<ParticipantGameEntity> participantGameEntityCaptor
         = ArgumentCaptor.forClass(ParticipantGameEntity.class);
-    ArgumentCaptor<ChatRoomEntity> chatRoomEntityCaptor
-        = ArgumentCaptor.forClass(ChatRoomEntity.class);
 
     verify(gameRepository).save(gameEntityCaptor.capture());
     verify(participantGameRepository).save(participantGameEntityCaptor.capture());
-    verify(chatRoomRepository).save(chatRoomEntityCaptor.capture());
 
     // 저장된 엔티티 캡처
     GameEntity savedGame = gameEntityCaptor.getValue();
     ParticipantGameEntity savedParticipantGame =
         participantGameEntityCaptor.getValue();
-    ChatRoomEntity savedChatRoom = chatRoomEntityCaptor.getValue();
 
     savedGame.setId(1L);
     savedGame.setCreatedDateTime(fixedCreatedDateTime);
 
     assertEquals(expectedCreatedGame, savedGame);
     assertEquals(expectedCreatorParticipantGame, savedParticipantGame);
-    assertEquals(expectedCreatedChatRoom, savedChatRoom);
+
   }
 
   @Test


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 채팅창에 A,B,C 가 접속한 상태에서 C가 다시 재접속 -> 이전 메세지를 불러옴
- 위의 경우 기존에 채팅방에 참여하던 A,B 채팅창에도 중복으로 메세지 출력

**TO-BE**
- 게임 생성시 OneToOne 관계로 채팅방이 개설됨 -> 방장이 승인한 유저가 채팅방에 접속시 새로운 채팅방 생성
  - 기존 Subscribe : "/topic/" + gameId 
  - 변경된 Subscribe : "/topic/" + gameId + "/" + nickName 
    - 각각의 채널주소 구분은 user의 고유값 nickName으로 설정하여 불필요한 세션 로직 제거
    - 게임 id + nickName 구조로 기존 프론트엔드 로직 변경 최소화
  - 유저가 메세지를 보낼 때는 ChatRoomEntity에서 참조하고 있는 GameEntity의 ID와 일치하는 ChatRoom을 list로 만들어서 각각의 채널에 메세지 전송
 ---
  ```java
    public void sendMessage(ChatMessage chatMessage, String gameId,
      String token) {

    Long gameIdNumber = Long.parseLong(gameId);
    UserEntity user = jwtTokenExtract.getUserFromToken(token);
    List<ChatRoomEntity> chatRoomEntityList = chatRoomRepository.findByGameEntity_Id(
        gameIdNumber);

    for (ChatRoomEntity chatRoomEntity : chatRoomEntityList) {
      String nickName = chatRoomEntity.getUserEntity().getNickName();

      MessageDto message = MessageDto.builder()
          .content(chatMessage.getContent())
          .build();

      messageRepository.save(message.toEntity(user, chatRoomEntity));
      messagingTemplate.convertAndSend("/topic/" + gameId + "/" + nickName,
          chatMessage);
    }
  }
  ```
  
- 기존에 채팅방 한 개로 그룹 채팅시 유저가 재접속할 경우 중복 메세지는 다음과 같이 해결
  - 유저 각각의 고유 채팅방이 존재하므로 Subscribe 하는 GameEntity id 와 유저의 ChatRoomEntity id가 일치하는 곳에 이전 메세지 로딩
  - 요약 : 기존과 달리 각각의 채팅방으로 분리 -> 재접속 유저만 따로 분리하여 이전 메세지 로딩
---
  ```java
    public void loadMessagesAndSend(String gameId, String token) {
    Long gameIdNumber = Long.parseLong(gameId);
    UserEntity user = jwtTokenExtract.getUserFromToken(token);

    ChatRoomEntity chatRoom = chatRoomRepository.findByGameEntity_IdAndUserEntity_Id(
            gameIdNumber, user.getId())
        .orElseThrow(
            () -> new CustomException(ErrorCode.NOT_EXIST_CHATROOM));

    List<MessageEntity> messages = messageRepository.findByChatRoomEntity(
        chatRoom);

    List<MessageConvertDto> messageDto = messages.stream()
        .map(this::convertToChatMessage)
        .collect(Collectors.toList());

    messagingTemplate.convertAndSend(
        "/topic/" + gameId + "/" + user.getNickName(), messageDto);
  }
  ```
⬇️ html로 간단히 구현한 프론트 페이지 입니다. 동작 테스트 및 확인하기 위해서 해당 파일을 다운로드 해주세요

[웹소켓 프론트 테스트 -버그수정(이전 채팅 내역 불러오기).zip](https://github.com/user-attachments/files/15937170/-.zip)

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [O] API 테스트 