### PR TITLE
[리펙토링] 웹시큐리티 로직 변경 / 이벤트 리스너 null 값 처리/ ChatServoce DIP / 테스트코드 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,78 +1,77 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.1.11'
-	id 'io.spring.dependency-management' version '1.1.4'
+    id 'java'
+    id 'org.springframework.boot' version '3.1.11'
+    id 'io.spring.dependency-management' version '1.1.4'
 }
 
 group = 'com.zerobase'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '17'
+    sourceCompatibility = '17'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-	implementation group: 'org.json', name: 'json', version: '20231013'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'org.springframework.boot:spring-boot-starter-mail'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation group: 'org.json', name: 'json', version: '20231013'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
-	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
-	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
-	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
-	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
-	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 
-	// swagger
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
-	implementation 'org.springframework.data:spring-data-envers'
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+    implementation 'org.springframework.data:spring-data-envers'
 
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 
-	// websocket 관련
-	implementation 'org.webjars:webjars-locator-core'
-	implementation 'org.webjars:sockjs-client:1.5.1'
-	implementation 'org.webjars:stomp-websocket:2.3.4'
-	implementation 'org.webjars:bootstrap:5.2.3'
-	implementation 'org.webjars:jquery:3.6.4'
+    // websocket 관련
+    implementation 'org.webjars:webjars-locator-core'
+    implementation 'org.webjars:sockjs-client:1.5.1'
+    implementation 'org.webjars:stomp-websocket:2.3.4'
 
-	// queryDsl 관련 코드생성 기능 제공
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	// queryDsl 라이브러리
-	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    // queryDsl 관련 코드생성 기능 제공
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+
+    // queryDsl 라이브러리
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
 }
 
 tasks.named('bootBuildImage') {
-	builder = 'paketobuildpacks/builder-jammy-base:latest'
+    builder = 'paketobuildpacks/builder-jammy-base:latest'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 ///// Querydsl 빌드 옵션 (옵셔널)
@@ -80,15 +79,15 @@ def generated = 'src/main/generated'
 
 ///// querydsl QClass 파일 생성 위치를 지정
 tasks.withType(JavaCompile).configureEach {
-	options.getGeneratedSourceOutputDirectory().set(file(generated))
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
 }
 
 ///// java source set 에 querydsl QClass 위치 추가
 sourceSets {
-	main.java.srcDirs += [ generated ]
+    main.java.srcDirs += [generated]
 }
 
 ///// gradle clean 시에 QClass 디렉토리 삭제
 clean {
-	delete file(generated)
+    delete file(generated)
 }

--- a/src/main/java/com/zerobase/hoops/chat/service/ChatService.java
+++ b/src/main/java/com/zerobase/hoops/chat/service/ChatService.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -26,7 +25,7 @@ import org.springframework.stereotype.Service;
 public class ChatService {
 
   private final ChatRoomRepository chatRoomRepository;
-  private final SimpMessagingTemplate messagingTemplate;
+  private final MessageSender messageSender;
   private final JwtTokenExtract jwtTokenExtract;
   private final MessageRepository messageRepository;
   private final GameRepository gameRepository;
@@ -49,7 +48,7 @@ public class ChatService {
           .build();
 
       messageRepository.save(message.toEntity(user, chatRoomEntity));
-      messagingTemplate.convertAndSend("/topic/" + gameId + "/" + nickName,
+      messageSender.send("/topic/" + gameId + "/" + nickName,
           chatMessage);
     }
     log.info("sendMessage 종료");
@@ -80,7 +79,7 @@ public class ChatService {
     for (ChatRoomEntity chatRoomEntity : chatRoomEntityList) {
       log.info("{} 채팅방 입장 메세지 전파", user.getNickName());
       String nickName = chatRoomEntity.getUserEntity().getNickName();
-      messagingTemplate.convertAndSend("/topic/" + gameId + "/" + nickName,
+      messageSender.send("/topic/" + gameId + "/" + nickName,
           chatMessage);
     }
 
@@ -106,7 +105,7 @@ public class ChatService {
         .map(this::convertToChatMessage)
         .collect(Collectors.toList());
 
-    messagingTemplate.convertAndSend(
+    messageSender.send(
         "/topic/" + gameId + "/" + user.getNickName(), messageDto);
     log.info("loadMessagesAndSend 종료");
   }

--- a/src/main/java/com/zerobase/hoops/chat/service/MessageSender.java
+++ b/src/main/java/com/zerobase/hoops/chat/service/MessageSender.java
@@ -1,0 +1,5 @@
+package com.zerobase.hoops.chat.service;
+
+public interface MessageSender {
+  void send(String destination, Object payload);
+}

--- a/src/main/java/com/zerobase/hoops/chat/service/WebSocketMessageSender.java
+++ b/src/main/java/com/zerobase/hoops/chat/service/WebSocketMessageSender.java
@@ -1,0 +1,18 @@
+package com.zerobase.hoops.chat.service;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WebSocketMessageSender implements MessageSender {
+  private final SimpMessagingTemplate messagingTemplate;
+
+  public WebSocketMessageSender(SimpMessagingTemplate messagingTemplate) {
+    this.messagingTemplate = messagingTemplate;
+  }
+
+  @Override
+  public void send(String destination, Object payload) {
+    messagingTemplate.convertAndSend(destination, payload);
+  }
+}

--- a/src/main/java/com/zerobase/hoops/config/WebSocketConnectionEventListener.java
+++ b/src/main/java/com/zerobase/hoops/config/WebSocketConnectionEventListener.java
@@ -58,7 +58,18 @@ public class WebSocketConnectionEventListener {
     if (sessionAttributes != null) {
       String username = (String) sessionAttributes.get("nickName");
       String gameId = (String) sessionAttributes.get("gameId");
-      Long gameIdNumber = Long.parseLong(gameId);
+
+      Long gameIdNumber = null;
+      if (gameId != null && !gameId.isEmpty()) {
+        try {
+          gameIdNumber = Long.parseLong(gameId);
+        } catch (NumberFormatException e) {
+          log.warn("Invalid user ID format: {}", gameId);
+        }
+      } else {
+        log.warn("User ID is null or empty");
+      }
+
       log.info("username={}", username);
       log.info("gameId={}", gameIdNumber);
       if (username != null) {

--- a/src/test/java/com/zerobase/hoops/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/zerobase/hoops/chat/service/ChatServiceTest.java
@@ -1,0 +1,171 @@
+package com.zerobase.hoops.chat.service;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.zerobase.hoops.chat.chat.ChatMessage;
+import com.zerobase.hoops.chat.repository.ChatRoomRepository;
+import com.zerobase.hoops.chat.repository.MessageRepository;
+import com.zerobase.hoops.entity.ChatRoomEntity;
+import com.zerobase.hoops.entity.GameEntity;
+import com.zerobase.hoops.entity.MessageEntity;
+import com.zerobase.hoops.entity.UserEntity;
+import com.zerobase.hoops.exception.CustomException;
+import com.zerobase.hoops.gameCreator.repository.GameRepository;
+import com.zerobase.hoops.security.JwtTokenExtract;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChatServiceTest {
+
+  @Mock
+  private ChatRoomRepository chatRoomRepository;
+
+  @Mock
+  private MessageSender messageSender;
+
+  @Mock
+  private JwtTokenExtract jwtTokenExtract;
+
+  @Mock
+  private MessageRepository messageRepository;
+
+  @Mock
+  private GameRepository gameRepository;
+
+  @InjectMocks
+  private ChatService chatService;
+
+  private UserEntity testUser;
+  private GameEntity testGame;
+  private ChatRoomEntity testChatRoom;
+  private ChatMessage testChatMessage;
+  private String testToken;
+  private String testGameId;
+
+  @BeforeEach
+  void setUp() {
+    testUser = UserEntity.builder()
+        .id(1L)
+        .nickName("TestUser1")
+        .build();
+
+    testGame = GameEntity.builder()
+        .id(1L)
+        .build();
+
+    testChatRoom = ChatRoomEntity.builder()
+        .id(1L)
+        .userEntity(testUser)
+        .gameEntity(testGame)
+        .build();
+
+    testChatMessage = ChatMessage.builder()
+        .content("Test Message")
+        .build();
+
+    testToken = "testToken";
+    testGameId = "1";
+
+    when(jwtTokenExtract.getUserFromToken(testToken)).thenReturn(testUser);
+  }
+  @DisplayName("메세지 보내기 성공")
+  @Test
+  void testSendMessage() {
+    when(chatRoomRepository.findByGameEntity_Id(1L)).thenReturn(
+        Collections.singletonList(testChatRoom));
+
+    chatService.sendMessage(testChatMessage, testGameId, testToken);
+
+    verify(messageRepository, times(1)).save(any(MessageEntity.class));
+    verify(messageSender, times(1)).send(eq("/topic/1/TestUser1"),
+        eq(testChatMessage));
+  }
+
+  @DisplayName("채팅방 입장 성공")
+  @Test
+  void testAddUser_ExistingChatRoom() {
+    when(gameRepository.findById(1L)).thenReturn(Optional.of(testGame));
+    when(chatRoomRepository.existsByGameEntity_IdAndUserEntity_Id(1L,
+        1L)).thenReturn(true);
+    when(chatRoomRepository.findByGameEntity_Id(1L)).thenReturn(
+        Collections.singletonList(testChatRoom));
+
+    chatService.addUser(testChatMessage, testGameId, testToken);
+
+    verify(chatRoomRepository, never()).save(any(ChatRoomEntity.class));
+    verify(messageSender, times(1)).send(eq("/topic/1/TestUser1"),
+        eq(testChatMessage));
+  }
+
+  @DisplayName("채팅방 만들기 성공")
+  @Test
+  void testAddUser_NewChatRoom() {
+    when(gameRepository.findById(1L)).thenReturn(Optional.of(testGame));
+    when(chatRoomRepository.existsByGameEntity_IdAndUserEntity_Id(1L,
+        1L)).thenReturn(false);
+    when(chatRoomRepository.findByGameEntity_Id(1L)).thenReturn(
+        Collections.singletonList(testChatRoom));
+
+    chatService.addUser(testChatMessage, testGameId, testToken);
+
+    verify(chatRoomRepository, times(1)).save(any(ChatRoomEntity.class));
+    verify(messageSender, times(1)).send(eq("/topic/1/TestUser1"),
+        eq(testChatMessage));
+  }
+
+  @DisplayName("채팅방이 존재하지 않을 때")
+  @Test
+  void testAddUser_GameNotFound() {
+    when(gameRepository.findById(1L)).thenReturn(Optional.empty());
+
+    assertThrows(CustomException.class, () -> {
+      chatService.addUser(testChatMessage, testGameId, testToken);
+    });
+  }
+
+  @DisplayName("채팅방 불러오기 및 메세지 보내기 성공")
+  @Test
+  void testLoadMessagesAndSend() {
+    MessageEntity testMessage = MessageEntity.builder()
+        .id(1L)
+        .user(testUser)
+        .content("Test Content")
+        .build();
+
+    when(chatRoomRepository.findByGameEntity_IdAndUserEntity_Id(1L, 1L))
+        .thenReturn(Optional.of(testChatRoom));
+    when(messageRepository.findByChatRoomEntity(testChatRoom))
+        .thenReturn(Arrays.asList(testMessage));
+
+    chatService.loadMessagesAndSend(testGameId, testToken);
+
+    verify(messageSender, times(1)).send(eq("/topic/1/TestUser1"), any(List.class));
+  }
+
+  @DisplayName("채팅방이 존재하지 않을 때 (승인되지 않았을 때) 실패")
+  @Test
+  void testLoadMessagesAndSend_ChatRoomNotFound() {
+    when(chatRoomRepository.findByGameEntity_IdAndUserEntity_Id(1L, 1L))
+        .thenReturn(Optional.empty());
+
+    assertThrows(CustomException.class, () -> {
+      chatService.loadMessagesAndSend(testGameId, testToken);
+    });
+  }
+}

--- a/src/test/java/com/zerobase/hoops/gameUsers/controller/GameUserControllerTest.java
+++ b/src/test/java/com/zerobase/hoops/gameUsers/controller/GameUserControllerTest.java
@@ -19,7 +19,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zerobase.hoops.commonResponse.ApiResponseFactory;
-import com.zerobase.hoops.commonResponse.BasicApiResponse;
 import com.zerobase.hoops.commonResponse.CustomApiResponse;
 import com.zerobase.hoops.entity.GameEntity;
 import com.zerobase.hoops.entity.MannerPointEntity;
@@ -51,6 +50,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Page;
@@ -61,6 +61,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @WebMvcTest(GameUserController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class GameUserControllerTest {
 
   @MockBean
@@ -150,9 +151,10 @@ class GameUserControllerTest {
             .with(csrf())
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(gameForManner)))
-        //.andDo(print())
+        .andDo(print())
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.detail").value("Success"));
+
   }
 
   @DisplayName("현재 게임 목록 테스트")


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
1. 로그인이 필요없는 부분에서도 토큰정보를 요구함 
2. 웹소켓 이벤트 리스너 null 처리 존재 x

**TO-BE**
1. 웹시큐리티 로직 변경

- 변경전 코드
```java
@Override
  protected void doFilterInternal(
      HttpServletRequest request,
      HttpServletResponse response,
      FilterChain filterChain) throws ServletException, IOException {

    String accessToken = resolveTokenFromRequest(request);
    try {
      if(accessToken != null && tokenProvider.validateToken(accessToken)) {
        Authentication auth = tokenProvider.getAuthentication(accessToken);
        SecurityContextHolder.getContext().setAuthentication(auth);
      } else {
        String requestURI = request.getRequestURI();
        if (!isPublicPath(requestURI)) {
          throw new AccessDeniedException("Access Denied");
        }
      }
    } catch (AccessDeniedException e) {
         ... 생략
      return;
    }
    filterChain.doFilter(request, response);
  }

    ...생략

  private boolean isPublicPath(String requestURI) {
    List<String> publicPaths = List.of(
        "/api/user", "/api/auth/login", "/api/oauth2/login/kakao",
        "/api/oauth2/kakao", "/swagger-ui", "/v3/api-docs", "/api/game-user",
        "/ws",
        "/api/game-creator/game/detail");
    return publicPaths.stream().anyMatch(requestURI::startsWith);
  }
```
- 게임 조회나 주소 검색 같은 경우 로그인 없이도 이용 가능 해야하지만 검색 시도시 토큰정보 요구
- 필터 로직에서 토큰 검사부터 먼저 진행되는 문제 발생
- publicPatrhs 가 의미가 없어지는 경우 존재

- 변경후 코드
```java

    String accessToken = resolveTokenFromRequest(request);
    String requestURI = request.getRequestURI();

    try {
      if (!isSearchPath(requestURI) && !authenticateRequest(accessToken,
          requestURI)) {
        throw new AccessDeniedException("Access Denied");
      }
      filterChain.doFilter(request, response);
    } catch (AccessDeniedException e) {
      handleAccessDenied(response);
    }
  }
  
  private boolean isSearchPath(String requestURI) {
    return requestURI.startsWith("/api/game-user/search")
        || requestURI.startsWith("/api/game-user/search-address");
  }
  
  private boolean authenticateRequest(String accessToken, String requestURI) {
    if (accessToken != null && tokenProvider.validateToken(accessToken)) {
      Authentication auth = tokenProvider.getAuthentication(accessToken);
      SecurityContextHolder.getContext().setAuthentication(auth);
      return true;
    }
    return isPublicPath(requestURI);
  }
```
- 토큰이 필요 없는 부분 앞부분 조건에 추가

2. 이벤트 리스너 null 처리 추가
```java
  if (sessionAttributes != null) {
      String username = (String) sessionAttributes.get("nickName");
      String gameId = (String) sessionAttributes.get("gameId");

      Long gameIdNumber = Long.parseLong(gameId); <--------- 이부분을 아래와 같이 null 처리

      // null 처리 
      Long gameIdNumber = null;
      if (gameId != null && !gameId.isEmpty()) {
        try {
          gameIdNumber = Long.parseLong(gameId);
        } catch (NumberFormatException e) {
          log.warn("Invalid user ID format: {}", gameId);
        }
      } else {
        log.warn("User ID is null or empty");
      }

      log.info("username={}", username);
      log.info("gameId={}", gameIdNumber);
      if (username != null) {
```
3. ChatService 의존성 분리
4. 테스트코드 추가

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [O] 테스트 코드
- [O] API 테스트 